### PR TITLE
Add USE_CUSTOM_PG_BUILD option

### DIFF
--- a/travis/install_custom_pg
+++ b/travis/install_custom_pg
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eux
+
+# exit early if a custom build is not needed
+if [ -z "${USE_CUSTOM_PG}" ]; then
+  exit
+fi
+
+# clone PostgreSQL
+cd ~
+git clone -b "REL${PGVERSION//./_}_STABLE" --depth 1 git://git.postgresql.org/git/postgresql.git
+
+# we will use this to parallelize PostgreSQL compilation
+procs="$(nproc)"
+mjobs="$((procs + 1))"
+
+# configure, build and install PostgreSQL
+cd postgresql
+./configure --enable-cassert --enable-debug --with-openssl \
+    --mandir="/usr/share/postgresql/${PGVERSION}/man" \
+    --docdir="/usr/share/doc/postgresql-doc-${PGVERSION}" \
+    --sysconfdir=/etc/postgresql-common \
+    --datarootdir=/usr/share/ \
+    --datadir="/usr/share/postgresql/${PGVERSION}" \
+    --bindir="/usr/lib/postgresql/${PGVERSION}/bin" \
+    --libdir=/usr/lib/x86_64-linux-gnu/ \
+    --libexecdir=/usr/lib/postgresql/ \
+    --includedir=/usr/include/postgresql/ \
+
+make -j "${mjobs}" -s all
+make -j "${mjobs}" -s -C src/test/isolation
+sudo make install
+
+# install postgresql-common to get psql wrappers, etc.
+sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install postgresql-common

--- a/travis/install_pg
+++ b/travis/install_pg
@@ -4,13 +4,18 @@
 
 set -eux
 
+# exit early if a custom build is needed
+if [ -n "${USE_CUSTOM_PG}" ]; then
+    exit
+fi
+
 # always install postgresql-common
 packages="postgresql-common libedit-dev libpam0g-dev libselinux1-dev"
 
 # we set PGVERSION to 10x of the Citus version when testing Citus, so
 # only install PostgreSQL proper if it's 10 or lower
 if [ "${PGVERSION//./}" -le "100" ]; then
-  packages="$packages postgresql-$PGVERSION postgresql-server-dev-$PGVERSION"
+    packages="$packages postgresql-$PGVERSION postgresql-server-dev-$PGVERSION"
 fi
 
 # shellcheck disable=SC2086

--- a/travis/nuke_pg
+++ b/travis/nuke_pg
@@ -7,6 +7,11 @@ set -eux
 # stop all existing instances (because of https://github.com/travis-ci/travis-cookbooks/pull/221)
 sudo service postgresql stop
 
+# remove existing installation of postgresql
+if [ -n "${USE_CUSTOM_PG}" ]; then
+    sudo apt-get --purge -y remove postgresql-*
+fi
+
 # and make sure they don't come back
 echo 'exit 0' | sudo tee /etc/init.d/postgresql
 sudo chmod a+x /etc/init.d/postgresql

--- a/travis/pg_travis_multi_test
+++ b/travis/pg_travis_multi_test
@@ -20,11 +20,20 @@ sudo make install
 # Change to test directory for remainder
 cd src/test/regress
 
+# if a custom build is in use, we will also run check-vanilla
+# and check-isolation along with regular regression tests
+if [ -n "${USE_CUSTOM_PG}" ]; then
+    testtargets="${testtargets} check-vanilla check-isolation"
+fi
+
 # Run tests. DBs owned by non-standard owner put socket in /tmp
 # shellcheck disable=SC2086
 make ${testtargets} || status=$?
 
 # Print diff if it exists
 if test -f regression.diffs; then cat regression.diffs; fi
+if test -f ~/postgresql/src/test/regress/regression.diffs; then
+    cat ~/postgresql/src/test/regress/regression.diffs
+fi
 
 exit $status


### PR DESCRIPTION
With this commit, we add USE_CUSTOM_PG_BUILD option to be able to run tests
against custom compiled PostgreSQL build. If this environment variable evaluates
to false or it is undefined, latest available PostgreSQL release will be
installed from Debian repositories.