### PR TITLE
Clean up citus_package output directories

### DIFF
--- a/travis/build_new_nightly
+++ b/travis/build_new_nightly
@@ -55,9 +55,10 @@ newcommitcount=$(curl -sf -H "${hubauth}" "${hubapiurl}" | jq -r 'length')
 
 if [ "${newcommitcount}" -gt 0 ]; then
     citus_package -p "${TARGET_PLATFORM}" 'local' nightly
-    mkdir nightlies
+    mkdir -p pkgs/nightlies
     shopt -s nullglob
-    cp ./*/*.rpm ./*/*.deb nightlies
+    mv ./*/*.rpm ./*/*.deb pkgs/nightlies
+    git clean -df -e pkgs
 else
     echo 'nightly up to date'
 fi

--- a/travis/build_new_release
+++ b/travis/build_new_release
@@ -50,9 +50,10 @@ needrelease=$(curl -sf -u "${pkgauth}" "${pkgapiurl}?per_page=1000" | \
 
 if [ "${needrelease}" == "true" ]; then
     citus_package -p "${TARGET_PLATFORM}" 'local' release
-    mkdir releases
+    mkdir -p pkgs/releases
     shopt -s nullglob
-    cp ./*/*.rpm ./*/*.deb releases
+    mv ./*/*.rpm ./*/*.deb pkgs/releases
+    git clean -df -e pkgs
 else
     echo 'release up to date'
 fi


### PR DESCRIPTION
Fixes a longstanding bug wherein Travis would fail to build a nightly and release at the same time.