### PR TITLE
Handle first release of new packages

### DIFF
--- a/travis/build_new_release
+++ b/travis/build_new_release
@@ -7,6 +7,7 @@ IFS=$'\n\t'
 # constants
 stderr=2
 badusage=64
+noservice=69
 
 pkgflavor="${TRAVIS_BRANCH%%-*}"
 pkgauth="${PACKAGECLOUD_API_TOKEN}:"
@@ -61,9 +62,23 @@ esac
 pkgapiurl="https://packagecloud.io/api/v1/repos/citusdata/${PKG_REPOTYPE}"
 pkgapiurl+="/package/${pkgflavor}/${TARGET_PLATFORM}/${pkgfull}/${pkgarch}/versions.json"
 
-needrelease=$(curl -sf -u "${pkgauth}" "${pkgapiurl}?per_page=1000" | \
-              jq -r "${jqfilter} | index(\"${pkglatest}\") < 0")
+response=$(curl -w '\n%{http_code}\n' -s -u "${pkgauth}" "${pkgapiurl}?per_page=1000")
 
+httpcode=$(echo "${response}" | tail -n1)
+case "${httpcode}" in
+    404)
+        httpbody='[]'
+        ;;
+    200)
+        httpbody=$(echo "${response}" | sed '$d')
+        ;;
+    *)
+        echo "$0: bad response code from packagecloud -- ${httpcode}" >&2
+        exit $noservice
+        ;;
+esac
+
+needrelease=$(echo "${httpbody}" | jq -r "${jqfilter} | index(\"${pkglatest}\") < 0")
 if [ "${needrelease}" == "true" ]; then
     citus_package -p "${TARGET_PLATFORM}" 'local' release
     mkdir -p pkgs/releases


### PR DESCRIPTION
This may or may not have been the case before, but now packagecloud returns a 404 status code when asking for the versions of a package which does not yet exist. Our code expected an empty array.

With a minor tweak, we can check for the 404 status code and interpose an empty array as the response body. Basically we ask that curl print the http code on a final line after the full response body. The rest is just shell scripting. This restores normal processing during the first build of a new package and maintains the old behavior for other status codes.