### PR TITLE
Use appropriate PostgreSQL branch

### DIFF
--- a/travis/install_custom_pg
+++ b/travis/install_custom_pg
@@ -16,10 +16,12 @@ cd ~
 if [ "$(ls -A postgresql)" ]; then
   git -C postgresql pull
 else
-  if [ "${PGVERSION}" -eq '10' ]; then
-    gitref='master'
+  if [ "${PGVERSION}" == '11' ]; then
+    gitref="master"
+  elif [ "${PGVERSION}" == '9.6' ]; then
+    gitref="REL9_6_STABLE"
   else
-    gitref="REL${PGVERSION//./_}_STABLE"
+    gitref="REL_${PGVERSION}_STABLE"
   fi
 
   git clone -b "${gitref}" --depth 1 git://git.postgresql.org/git/postgresql.git


### PR DESCRIPTION
PostgreSQL master branch is now stamped with 11devel and we should only
use it if we want to test against PostgreSQL 11. For PostgreSQL 9.6
tests we should use REL9_6_STABLE and for PostgreSQL 10 we should use
REL_10_STABLE (Notice extra _ after REL).