### PR TITLE
Add Debian Stretch to supported versions for packaging

### DIFF
--- a/packaging/citus_package
+++ b/packaging/citus_package
@@ -25,7 +25,7 @@ use constant PACKAGE_URL =>       ## no critic (ProhibitConstantPragma)
   'https://github.com/citusdata/packaging/archive';
 
 my %supported_platforms = (
-    debian => [ "jessie", "wheezy" ],
+    debian => [ "jessie", "wheezy", "stretch" ],
     el     => [ "7",      "6" ],
     fedora => [ "23",     "22", "24" ],
     ol     => [ "7",      "6" ],
@@ -493,6 +493,8 @@ to sign packages.
 =head1 SUPPORTED PLATFORMS
 
 =over 4
+
+=item I<debian/stretch>  Debian 9 "Stretch"
 
 =item I<debian/jessie>  Debian 8 "Jessie"
 


### PR DESCRIPTION
New version of Debian is released at 2017-06-17. We already added necessary
scripts to our packaging repo. Here, we just specify it as a supported
version.