### PR TITLE
Improve Travis custom build/apt logic

### DIFF
--- a/travis/install_custom_pg
+++ b/travis/install_custom_pg
@@ -16,12 +16,14 @@ cd ~
 if [ "$(ls -A postgresql)" ]; then
   git -C postgresql pull
 else
-  if [ "${PGVERSION}" == '11' ]; then
+  pgmajornum="${PGVERSION%%.*}"
+  if [ "${pgmajornum}" -gt '10' ]; then
+    # ten is highest stable build; use master for higher
     gitref="master"
-  elif [ "${PGVERSION}" == '9.6' ]; then
-    gitref="REL9_6_STABLE"
-  else
+  elif [ "${pgmajornum}" -gt '9' ]; then
     gitref="REL_${PGVERSION}_STABLE"
+  else
+    gitref="REL${PGVERSION//./_}_STABLE"
   fi
 
   git clone -b "${gitref}" --depth 1 git://git.postgresql.org/git/postgresql.git

--- a/travis/install_custom_pg
+++ b/travis/install_custom_pg
@@ -43,7 +43,7 @@ mjobs="$((procs + 1))"
 
 # configure, build, and install PostgreSQL
 cd postgresql
-./configure --enable-cassert --enable-debug --with-openssl \
+./configure --enable-cassert --enable-debug --enable-depend --with-openssl \
     --mandir="/usr/share/postgresql/${PGVERSION}/man" \
     --docdir="/usr/share/doc/postgresql-doc-${PGVERSION}" \
     --sysconfdir=/etc/postgresql-common \

--- a/travis/setup_apt
+++ b/travis/setup_apt
@@ -10,14 +10,16 @@ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ACCC4CF8
 # wtf, Google?
 sudo rm /etc/apt/sources.list.d/google-chrome*
 
-# add the PostgreSQL 9.5 repository
+# add the PostgreSQL 9.5 and 10 repositories
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 10" >> /etc/apt/sources.list.d/postgresql.list'
 
-if [ "${PGVERSION}" == "10" ]; then
-    # add the PostgreSQL 10 testing repository
-    sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg-testing main 10" >> /etc/apt/sources.list.d/postgresql.list'
+# need testing repository after version 10
+if [ "${PGVERSION%%.*}" -gt '10' ]; then
+    # add a PostgreSQL testing repository
+    sudo sh -Ec 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg-testing main ${PGVERSION}" >> /etc/apt/sources.list.d/postgresql.list'
 
-    sudo sh -c 'echo "Package: *\nPin: release n=trusty-pgdg-testing\nPin-Priority: 600" >> /etc/apt/preferences.d/postgresql.pref'
+    sudo sh -c 'echo "Package: *\nPin: release n=$(lsb_release -cs)-pgdg-testing\nPin-Priority: 600" >> /etc/apt/preferences.d/postgresql.pref'
 fi
 
 # update package index files from sources


### PR DESCRIPTION
Previous changes had some problems (such as not handling pre-9.6 PostgreSQL). When I went to look at that, I realized we could keep testing against `master` in the future and set about getting that going. PostgreSQL 11 testing packages now exist, so we can use those and build against `master` in the PR builds.

This also adds `enable-depend` to help with the cache invalidation problems we were having in Travis (i.e. when a header changed but an object wasn't rebuilt because dependency tracking was off).