### PR TITLE
Add libcurl to valgrind test dependencies

### DIFF
--- a/valgrind/run-valgrind-tests
+++ b/valgrind/run-valgrind-tests
@@ -13,7 +13,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     bison \
     libssl-dev \
     valgrind \
-    mailutils
+    mailutils \
+    libcurl4-openssl-dev
 
 # set environment variables
 export LC_ALL=en_US.UTF-8


### PR DESCRIPTION
We also need to install libcurl now. Look at: https://github.com/citusdata/citus/pull/1656