### PR TITLE
Save docker build logs to file

### DIFF
--- a/travis/build_new_nightly
+++ b/travis/build_new_nightly
@@ -69,7 +69,7 @@ hubapiurl+="sha=${nightlyref}&since=${lastnightly}&per_page=1"
 newcommitcount=$(curl -sf -H "${hubauth}" "${hubapiurl}" | jq -r 'length')
 
 if [ "${newcommitcount}" -gt 0 ]; then
-    citus_package -p "${TARGET_PLATFORM}" 'local' nightly
+    citus_package -p "${TARGET_PLATFORM}" 'local' nightly > citus_package.log
     mkdir -p pkgs/nightlies
     shopt -s nullglob
     mv ./*/*.rpm ./*/*.deb pkgs/nightlies

--- a/travis/build_new_release
+++ b/travis/build_new_release
@@ -80,7 +80,7 @@ esac
 
 needrelease=$(echo "${httpbody}" | jq -r "${jqfilter} | index(\"${pkglatest}\") < 0")
 if [ "${needrelease}" == "true" ]; then
-    citus_package -p "${TARGET_PLATFORM}" 'local' release
+    citus_package -p "${TARGET_PLATFORM}" 'local' release > citus_package.log
     mkdir -p pkgs/releases
     shopt -s nullglob
     mv ./*/*.rpm ./*/*.deb pkgs/releases


### PR DESCRIPTION
Save docker build's log to citus_package file. It will be used on packaging repo to check whether there exist an error on builds.