### PR TITLE
Use bigger instance for valgrind tests

### DIFF
--- a/valgrind/Makefile
+++ b/valgrind/Makefile
@@ -7,7 +7,6 @@ VALGRIND_SCRIPTS := $(filter-out README.md Makefile,$(wildcard *))
 all:
 
 clean:
-	rm -f $(VALGRIND_SCRIPTS)
 
 install: all
 	$(INSTALL_SCRIPT) $(VALGRIND_SCRIPTS) $(DESTDIR)$(bindir)

--- a/valgrind/launch-test-instance
+++ b/valgrind/launch-test-instance
@@ -13,10 +13,10 @@ echo "Starting an instance..."
 valgrind_instance_id=$(aws ec2 run-instances \
     --image-id ami-f4cc1de2 \
     --count 1 \
-    --instance-type m3.xlarge \
+    --instance-type r3.2xlarge \
     --key-name $key_name \
     --instance-initiated-shutdown-behavior terminate \
-    --user-data file://download-test-scripts \
+    --user-data file:///usr/local/bin/download-test-scripts \
     --query 'Instances[0].InstanceId' \
     --output text)
 

--- a/valgrind/run-valgrind-tests
+++ b/valgrind/run-valgrind-tests
@@ -60,9 +60,9 @@ if [ -s regression.diffs ]; then
 fi
 
 if [ -z "$attachments" ]; then
-    mail -aFrom:valgrind-test@citusdata.com -s "[Valgrind Test Results] - Success" burak@citusdata.com metin@citusdata.com < /dev/null
+    mail -aFrom:valgrind-test@citusdata.com -s "[Valgrind Test Results] - Success" burak@citusdata.com metin@citusdata.com furkan@citusdata.com < /dev/null
 else
-    mail -aFrom:valgrind-test@citusdata.com -s "[Valgrind Test Results] - Failure" $attachments burak@citusdata.com metin@citusdata.com < /dev/null
+    mail -aFrom:valgrind-test@citusdata.com -s "[Valgrind Test Results] - Failure" $attachments burak@citusdata.com metin@citusdata.com furkan@citusdata.com < /dev/null
 fi
 
 # just to ensure everything is completed in the test instance


### PR DESCRIPTION
Since our tests become more memory intensive, we had errors in
valgrind tests due to available memory is not enough for valgrind.
We are starting to use bigger instance to solve this issue.

We also made some quick fixes to the scripts such as;
- adding @furkansahin to the list of people who receives test results
- removing clean section from Makefile because that was wrong in
the first place, it used to remove the actual scripts not the build
artifacts (we don't have build artifacts anyway)
- prepending install path to the path of user-data script. Adding
hardcoded path is bit hacky there but it is quick & dirty solution.
(This used to cause problems during deployment and we used
to fix this manually)