### PR TITLE
Install pg_stat_statements along with postgres

### DIFF
--- a/travis/install_custom_pg
+++ b/travis/install_custom_pg
@@ -58,7 +58,10 @@ cd postgresql
 
 make -j "${mjobs}" -s all
 make -j "${mjobs}" -s -C src/test/isolation
+make -j "${mjobs}" -s -C contrib/pg_stat_statements
+
 sudo make install
+sudo make -C contrib/pg_stat_statements install
 
 # install postgresql-common to get psql wrappers, etc.
 sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install postgresql-common

--- a/travis/install_pg
+++ b/travis/install_pg
@@ -10,7 +10,7 @@ if [ -n "${USE_CUSTOM_PG:-}" ]; then
 fi
 
 # always install postgresql-common
-packages="postgresql-common libedit-dev libpam0g-dev libselinux1-dev"
+packages="postgresql-common postgresql-contrib-$PGVERSION libedit-dev libpam0g-dev libselinux1-dev"
 
 # we set PGVERSION to 10x of the Citus version when testing Citus, so
 # only install PostgreSQL proper if it's 10 or lower


### PR DESCRIPTION
Needed  this to test citus_stat_statements in travis
- loads postgres-contrib package when installing postgres from package
- compiles and installs from contrib/pg_stat_statements when installing postgres from sources