### PR TITLE
Send emails to both citus and MS addresses

### DIFF
--- a/valgrind/launch-test-instance
+++ b/valgrind/launch-test-instance
@@ -2,7 +2,13 @@
 
 set -euo pipefail
 
-REPORT_EMAIL=${REPORT_EMAIL:-burak@citusdata.com metin@citusdata.com furkan@citusdata.com}
+REPORT_EMAIL=${REPORT_EMAIL:-burak@citusdata.com \
+                             furkan@citusdata.com \
+                             metin@citusdata.com \
+                             Burak.Yucesoy@microsoft.com \
+                             Furkan.Sahin@microsoft.com \
+                             Hanefi.Onaldi@microsoft.com \
+                             Metin.Doslu@microsoft.com }
 POSTGRES_GITREF=${POSTGRES_GITREF:-REL_11_STABLE}
 CITUS_GITREF=${CITUS_GITREF:-master}
 

--- a/valgrind/run-valgrind-tests
+++ b/valgrind/run-valgrind-tests
@@ -2,7 +2,13 @@
 
 set -euo pipefail
 
-REPORT_EMAIL=${REPORT_EMAIL:-burak@citusdata.com metin@citusdata.com furkan@citusdata.com}
+REPORT_EMAIL=${REPORT_EMAIL:-burak@citusdata.com \
+                             furkan@citusdata.com \
+                             metin@citusdata.com \
+                             Burak.Yucesoy@microsoft.com \
+                             Furkan.Sahin@microsoft.com \
+                             Hanefi.Onaldi@microsoft.com \
+                             Metin.Doslu@microsoft.com }
 CITUS_GITREF=${CITUS_GITREF:-master}
 POSTGRES_GITREF=${POSTGRES_GITREF:-REL_11_STABLE}
 


### PR DESCRIPTION
We want to receive the valgrind results in our Microsoft inboxes. We will gradually make this transition to make sure no email gets lost by being marked as spam. If we confirm that we receive the reports, only then we will drop citus mails.