### PR TITLE
Remove citus hack as it interferes with other repos, & citus is using circle

### DIFF
--- a/travis/install_pg
+++ b/travis/install_pg
@@ -10,13 +10,7 @@ if [ -n "${USE_CUSTOM_PG:-}" ]; then
 fi
 
 # always install postgresql-common
-packages="postgresql-common postgresql-contrib-$PGVERSION libedit-dev libpam0g-dev libselinux1-dev"
-
-# we set PGVERSION to 10x of the Citus version when testing Citus, so
-# only install PostgreSQL proper if it's 10 or lower
-if [ "${PGVERSION//./}" -le "100" ]; then
-    packages="$packages postgresql-$PGVERSION postgresql-server-dev-$PGVERSION"
-fi
+packages="postgresql-common postgresql-contrib-$PGVERSION libedit-dev libpam0g-dev libselinux1-dev postgresql-$PGVERSION postgresql-server-dev-$PGVERSION"
 
 # shellcheck disable=SC2086
 sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install $packages

--- a/travis/setup_apt
+++ b/travis/setup_apt
@@ -10,9 +10,8 @@ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ACCC4CF8
 # wtf, Google?
 sudo rm /etc/apt/sources.list.d/google-chrome*
 
-# add the PostgreSQL 9.5 and 10 repositories
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 10" >> /etc/apt/sources.list.d/postgresql.list'
+# add the PostgreSQL repositories
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main ${PGVERSION}" >> /etc/apt/sources.list.d/postgresql.list'
 
 # need testing repository after version 10
 if [ "${PGVERSION%%.*}" -gt '10' ]; then


### PR DESCRIPTION
https://github.com/citusdata/postgresql-hll/pull/73

Is failing because after updating the sql script generation to use the C preprocessor, PG_VERSION for 9.6 was 100001

Looking over scripts, bit unsure with 9.5 being listed without 9.4 or 9.6 in [setup_apt](https://github.com/citusdata/tools/blob/develop/travis/setup_apt)

I should probably test this by submitting a pull request to postgresql-hll which uses the `fix_travis` branch