### PR TITLE
Include --replace with --no-backup for uncrustify

### DIFF
--- a/uncrustify/citus_indent
+++ b/uncrustify/citus_indent
@@ -29,7 +29,14 @@ my @files_to_format = ();
 my @formatter_args = qw(-c /usr/local/etc/citustools/citus-style.cfg);
 
 push @formatter_args, '-q' if $quiet;
-push @formatter_args, ($check ? '--check' : '--no-backup');
+if ($check)
+{
+	push @formatter_args, '--check';
+}
+else
+{
+	push @formatter_args, '--no-backup', '--replace';
+}
 
 while(my ($filename, $attrname, $attrvalue) = splice(@flattened_triples, 0, 3)) {
     next unless $attrvalue eq 'set';


### PR DESCRIPTION
My Debian uncrustify veresion is 0.69.0_f
See https://github.com/uncrustify/uncrustify/issues/2313

Recent Debian update _(not sure why they updated to a not-recent version)_ had citus_indent leaving *.uncrustify files instead of replacing