### PR TITLE
Some cleanup and introduce PG12

### DIFF
--- a/travis/config_and_start_cluster
+++ b/travis/config_and_start_cluster
@@ -19,4 +19,4 @@ then
 fi
 
 # Start cluster
-sudo pg_ctlcluster "${PGVERSION}" test start
+pg_ctlcluster "${PGVERSION}" test start

--- a/travis/install_custom_pg
+++ b/travis/install_custom_pg
@@ -17,8 +17,8 @@ if [ "$(ls -A postgresql)" ]; then
   git -C postgresql pull
 else
   pgmajornum="${PGVERSION%%.*}"
-  if [ "${pgmajornum}" -gt '11' ]; then
-    # eleven is highest stable build; use master for higher
+  if [ "${pgmajornum}" -gt '12' ]; then
+    # twelve is highest stable build; use master for higher
     gitref="master"
   elif [ "${pgmajornum}" -gt '9' ]; then
     gitref="REL_${PGVERSION}_STABLE"

--- a/travis/install_pg
+++ b/travis/install_pg
@@ -12,11 +12,7 @@ fi
 # always install postgresql-common
 packages="postgresql-common postgresql-contrib-$PGVERSION libedit-dev libpam0g-dev libselinux1-dev"
 
-# we set PGVERSION to 10x of the Citus version when testing Citus, so
-# only install PostgreSQL proper if it's 10 or lower
-if [ "${PGVERSION//./}" -le "100" ]; then
-    packages="$packages postgresql-$PGVERSION postgresql-server-dev-$PGVERSION"
-fi
+packages="$packages postgresql-$PGVERSION postgresql-server-dev-$PGVERSION"
 
 # shellcheck disable=SC2086
 sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install $packages

--- a/travis/nuke_pg
+++ b/travis/nuke_pg
@@ -8,9 +8,7 @@ set -eux
 sudo service postgresql stop
 
 # remove existing installation of postgresql
-if [ -n "${USE_CUSTOM_PG:-}" ]; then
-    sudo apt-get --purge -y remove postgresql-*
-fi
+sudo apt-get --purge -y remove postgresql-*
 
 # and make sure they don't come back
 echo 'exit 0' | sudo tee /etc/init.d/postgresql

--- a/travis/setup_apt
+++ b/travis/setup_apt
@@ -6,16 +6,17 @@ set -eux
 
 # import the PostgreSQL repository key
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ACCC4CF8
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7FCC7D46ACCC4CF8
 
 # wtf, Google?
-sudo rm /etc/apt/sources.list.d/google-chrome*
+sudo rm -f /etc/apt/sources.list.d/google-chrome*
+sudo rm -f /etc/apt/sources.list.d/pgdg.list
 
-# add the PostgreSQL 9.5 and 10 repositories
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 10" >> /etc/apt/sources.list.d/postgresql.list'
+# add the PostgreSQL 12 repository
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 12" >> /etc/apt/sources.list.d/postgresql.list'
 
-# need testing repository after version 10
-if [ "${PGVERSION%%.*}" -gt '10' ]; then
+# need testing repository after version 12
+if [ "${PGVERSION%%.*}" -gt '12' ]; then
     # add a PostgreSQL testing repository
     sudo sh -Ec 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg-testing main ${PGVERSION}" >> /etc/apt/sources.list.d/postgresql.list'
 


### PR DESCRIPTION
We can now use PGVERSION=12 in travis files.

Notice that PG stopped creating packages for ubuntu trusty. We should be using ubuntu bionic (18.04) from this point onward.  See the usage in pg_auto_failover, hll or cstore_fdw projects. 

Some package names or dependencies may have changed in the new OS. Make sure your package compiles in ubuntu 18.04 with dependencies set in your travis.yml file

