### PR TITLE
Make citus_dev compatible with any user

### DIFF
--- a/citus_dev/citus_dev
+++ b/citus_dev/citus_dev
@@ -22,6 +22,7 @@ from subprocess import call
 from subprocess import Popen, PIPE
 import os
 import sys
+import getpass
 
 
 def createNodeCommands(clustername, role, index=None, usessl=False, mx=False):
@@ -103,6 +104,9 @@ def main(arguments):
             port += 1
         port = cport
 
+        if getpass.getuser() != "postgres":
+            for i in range(size + 1):
+                cs.append('createdb -p %d' % (port + i))
 
         if not arguments["--no-extension"]:
             for i in range(size + 1):


### PR DESCRIPTION
If the user is not `postgres`, a new database is created with user's name on every node. This allows that `citus_dev` can be used with any user.