### PR TITLE
support uncrustify to 0.70.1

### DIFF
--- a/uncrustify/README.md
+++ b/uncrustify/README.md
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-`citus_indent` requires `uncrustify` v0.68 or greater.
+`citus_indent` requires `uncrustify` v0.70.0 or greater.
 
 `make install` to install the script, the Citus style configuration file, and a man page. `man citus_indent` for more details.
 

--- a/uncrustify/citus-style.cfg
+++ b/uncrustify/citus-style.cfg
@@ -267,7 +267,7 @@ sp_assign                                 = force   # ignore/add/remove/force
 sp_cpp_lambda_assign                      = ignore   # ignore/add/remove/force
 
 # Add or remove space after the capture specification in C++11 lambda.
-sp_cpp_lambda_paren                       = ignore   # ignore/add/remove/force
+sp_cpp_lambda_square_paren                = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=' in a prototype
 sp_assign_default                         = ignore   # ignore/add/remove/force


### PR DESCRIPTION
option 'sp_cpp_lambda_paren' is deprecated; use 'sp_cpp_lambda_square_paren' instead