### PR TITLE
Forward PACKAGE_ENCRYPTION_KEY to packaging docker containers

### DIFF
--- a/packaging/citus_package
+++ b/packaging/citus_package
@@ -369,6 +369,8 @@ foreach my $platform (@platforms) {
             "$filesubdir:/buildfiles:ro",
             '-e',
             "GITHUB_TOKEN",
+            '-e',
+            "PACKAGE_ENCRYPTION_KEY",
             "citus/packaging:$docker_platform-$pg",
             $build_type
         );


### PR DESCRIPTION
This encryption key is needed in the container to encrypt the package contents