### PR TITLE
Some useful improvements for our release script

### DIFF
--- a/automated_packaging/common_functions.pm
+++ b/automated_packaging/common_functions.pm
@@ -6,10 +6,28 @@ use JSON;
 
 # Export subroutines
 our @ISA = qw(Exporter);
-our @EXPORT = qw(get_and_verify_token get_sorted_prs create_release_changelog has_backport_label);
+our @EXPORT = qw(get_and_verify_token get_microsoft_email get_git_name get_sorted_prs create_release_changelog has_backport_label);
 
 # untaint environment
 local $ENV{'PATH'} = '/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin';
+
+sub get_microsoft_email {
+    unless (exists $ENV{MICROSOFT_EMAIL}) {
+        die "You must have a MICROSOFT_EMAIL set";
+    }
+
+    my $microsoft_email = $ENV{MICROSOFT_EMAIL};
+    return $microsoft_email;
+}
+
+sub get_git_name {
+    my $git_name = `git config user.name`;
+    if ($git_name eq "") {
+        die "You must set your git name using 'git config user.name \"Your name Here\"'";
+    }
+    return $microsoft_email;
+}
+
 
 sub get_and_verify_token {
     unless (exists $ENV{GITHUB_TOKEN}) {

--- a/automated_packaging/common_functions.pm
+++ b/automated_packaging/common_functions.pm
@@ -22,10 +22,12 @@ sub get_microsoft_email {
 
 sub get_git_name {
     my $git_name = `git config user.name`;
+    # Strip trailing newline
+    chomp $git_name;
     if ($git_name eq "") {
         die "You must set your git name using 'git config user.name \"Your name Here\"'";
     }
-    return $microsoft_email;
+    return $git_name;
 }
 
 

--- a/automated_packaging/update_os_package.pl
+++ b/automated_packaging/update_os_package.pl
@@ -23,7 +23,7 @@ my $git_name = get_git_name();
 sub get_changelog_for_debian {
 
     # Update project spec file
-    @changelog_file = `curl --user "$github_token:x-oauth-basic" -H "Accept: application/vnd.github.v3.raw" -X GET 'https://api.github.com/repos/citusdata/$github_repo_name/contents/CHANGELOG.md' 2> /dev/null`;
+    @changelog_file = `curl --user "$github_token:x-oauth-basic" -H "Accept: application/vnd.github.v3.raw" -X GET 'https://api.github.com/repos/citusdata/$github_repo_name/contents/CHANGELOG.md?ref=v$VERSION' 2> /dev/null`;
 
     $first_version_has_seen = 0;
     my @changelog_items;

--- a/automated_packaging/update_os_package.pl
+++ b/automated_packaging/update_os_package.pl
@@ -16,6 +16,9 @@ if ( $PROJECT eq "enterprise" ) {
 
 my $github_token = get_and_verify_token();
 
+my $microsoft_email = get_microsoft_email();
+my $git_name = get_git_name();
+
 # Debian branch has it's own changelog, we can get them through the CHANGELOG file of the code repo
 sub get_changelog_for_debian {
 
@@ -66,8 +69,8 @@ $curTime = time();
 # Based on the repo, update the package related variables
 if ( $DISTRO_VERSION eq "redhat" ) {
     `sed -i 's|^Version:.*|Version:	$VERSION.citus|g' $github_repo_name.spec`;
-    `sed -i 's|^Source0:.*|Source0:       https:\/\/github.com\/citusdata\/$github_repo_name\/archive\/v$VERSION.tar.gz|g' $github_repo_name.spec`;
-    `sed -i 's|^%changelog|%changelog\\n* $abbr_day[$wday] $abbr_mon[$mon] $mday $year - Burak Velioglu <velioglub\@citusdata.com> $VERSION.citus-1\\n- Update to $log_repo_name $VERSION\\n|g' $github_repo_name.spec`;
+    `sed -i 's|^Source0:.*|Source0:	https:\/\/github.com\/citusdata\/$github_repo_name\/archive\/v$VERSION.tar.gz|g' $github_repo_name.spec`;
+    `sed -i 's|^%changelog|%changelog\\n* $abbr_day[$wday] $abbr_mon[$mon] $mday $year - $git_name <$microsoft_email> $VERSION.citus-1\\n- Update to $log_repo_name $VERSION\\n|g' $github_repo_name.spec`;
 }
 elsif ( $DISTRO_VERSION eq "debian" ) {
     open( DEB_CLOG_FILE, "<./debian/changelog" ) || die "Debian changelog file not found";
@@ -82,7 +85,7 @@ elsif ( $DISTRO_VERSION eq "debian" ) {
     open( DEB_CLOG_FILE, ">./debian/changelog" ) || die "Debian changelog file not found";
     print DEB_CLOG_FILE "$github_repo_name ($VERSION.citus-1) stable; urgency=low\n";
     print DEB_CLOG_FILE @changelog_print;
-    print DEB_CLOG_FILE " -- Burak Velioglu <velioglub\@citusdata.com>  $abbr_day[$wday], $mday $abbr_mon[$mon] $year $print_hour:$min:$sec +0000\n\n";
+    print DEB_CLOG_FILE " -- $git_name <$microsoft_email>  $abbr_day[$wday], $mday $abbr_mon[$mon] $year $print_hour:$min:$sec +0000\n\n";
     print DEB_CLOG_FILE @lines;
     close(DEB_CLOG_FILE);
 }

--- a/automated_packaging/update_os_package.pl
+++ b/automated_packaging/update_os_package.pl
@@ -95,4 +95,4 @@ if ( $DISTRO_VERSION eq "debian" || $DISTRO_VERSION eq "microsoft") {
 # Commit, push changes and open a pull request
 `git commit -a -m "Bump $DISTRO_VERSION $log_repo_name $VERSION"`;
 `git push origin $DISTRO_VERSION-$PROJECT-push-$curTime`;
-`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump $PROJECT $DISTRO_VERSION Version to $VERSION\", \"head\":\"$DISTRO_VERSION-$PROJECT-push-$curTime\", \"base\":\"$DISTRO_VERSION-$PROJECT\"}' https://api.github.com/repos/citusdata/packaging/pulls`;
+`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump $PROJECT $DISTRO_VERSION version to $VERSION\", \"head\":\"$DISTRO_VERSION-$PROJECT-push-$curTime\", \"base\":\"$DISTRO_VERSION-$PROJECT\"}' https://api.github.com/repos/citusdata/packaging/pulls`;

--- a/automated_packaging/update_os_package.pl
+++ b/automated_packaging/update_os_package.pl
@@ -95,4 +95,4 @@ elsif ( $DISTRO_VERSION eq "debian" ) {
 # Commit, push changes and open a pull request
 `git commit -a -m "Bump $DISTRO_VERSION $log_repo_name $VERSION"`;
 `git push origin $DISTRO_VERSION-$PROJECT-push-$curTime`;
-`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump $PROJECT $DISTRO_VERSION Version\", \"head\":\"$DISTRO_VERSION-$PROJECT-push-$curTime\", \"base\":\"$DISTRO_VERSION-$PROJECT\"}' https://api.github.com/repos/citusdata/packaging/pulls`;
+`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump $PROJECT $DISTRO_VERSION Version to $VERSION\", \"head\":\"$DISTRO_VERSION-$PROJECT-push-$curTime\", \"base\":\"$DISTRO_VERSION-$PROJECT\"}' https://api.github.com/repos/citusdata/packaging/pulls`;

--- a/automated_packaging/update_os_package.pl
+++ b/automated_packaging/update_os_package.pl
@@ -69,12 +69,12 @@ $curTime = time();
 `sed -i 's/^pkglatest.*/pkglatest=$VERSION.citus-1/g' pkgvars`;
 
 # Based on the repo, update the package related variables
-if ( $DISTRO_VERSION eq "redhat" ) {
+if ( $DISTRO_VERSION eq "redhat" || $DISTRO_VERSION eq "microsoft") {
     `sed -i 's|^Version:.*|Version:	$VERSION.citus|g' $github_repo_name.spec`;
     `sed -i 's|^Source0:.*|Source0:	https:\/\/github.com\/citusdata\/$github_repo_name\/archive\/v$VERSION.tar.gz|g' $github_repo_name.spec`;
     `sed -i 's|^%changelog|%changelog\\n* $abbr_day[$wday] $abbr_mon[$mon] $mday $year - $git_name <$microsoft_email> $VERSION.citus-1\\n- Update to $log_repo_name $VERSION\\n|g' $github_repo_name.spec`;
 }
-elsif ( $DISTRO_VERSION eq "debian" ) {
+if ( $DISTRO_VERSION eq "debian" || $DISTRO_VERSION eq "microsoft") {
     open( DEB_CLOG_FILE, "<./debian/changelog" ) || die "Debian changelog file not found";
     my @lines = <DEB_CLOG_FILE>;
     close(DEB_CLOG_FILE);

--- a/automated_packaging/update_os_package.pl
+++ b/automated_packaging/update_os_package.pl
@@ -59,6 +59,8 @@ $curTime = time();
 
 # Checkout the distro's branch
 `git checkout $DISTRO_VERSION-$PROJECT`;
+# Update distro's branch
+`git pull origin $DISTRO_VERSION-$PROJECT`;
 
 # Create a new branch based on the distro's branch
 `git checkout -b $DISTRO_VERSION-$PROJECT-push-$curTime`;


### PR DESCRIPTION
This does the following things:

* Remove weird casing in PR title
* Add support for the Microsoft "distro"
* Include version in PR title
* Pull distro branch before creating a new branch
* Get debian changelog from tag, not from default branch
* Make Veliogliu not the default releaser anymore

The only difference to the user is that you should now set `MICROSFT_EMAIL` environment variable.