### PR TITLE
Update uncrustify on travis to 0.68.1

### DIFF
--- a/travis/install_uncrustify
+++ b/travis/install_uncrustify
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-set -eux
+set -euxo pipefail
 
-uncrustifypkgs="$HOME/.cache/uncrustify_pkgs"
-uncrustifyversion="0.63"
-uncrustifydownload="uncrustify_${uncrustifyversion}-1_amd64.deb"
-uncrustifyurl="https://s3.amazonaws.com/packages.citusdata.com/travis/${uncrustifydownload}"
-
-# install travis uncrustify package
-wget -N -P "${uncrustifypkgs}" "${uncrustifyurl}"
-sudo dpkg --force-confdef --force-confold --install "${uncrustifypkgs}/${uncrustifydownload}"
+curl -L https://github.com/uncrustify/uncrustify/archive/uncrustify-0.68.1.tar.gz | tar xz
+cd uncrustify-uncrustify-0.68.1/
+mkdir build
+cd build
+cmake ..
+make -j5
+sudo make install
+cd ../..


### PR DESCRIPTION
Needed for pg_auto_failover automation