### PR TITLE
Do not open pr against docker/develop when creating docker images

### DIFF
--- a/automated_packaging/update_docker.pl
+++ b/automated_packaging/update_docker.pl
@@ -61,8 +61,3 @@ close(CHANGELOG);
 `git commit -a -m "Bump to version $VERSION"`;
 `git push origin release-$VERSION-$curTime`;
 `curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump docker to $VERSION\", \"base\":\"master\", \"head\":\"release-$VERSION-$curTime\"}' https://api.github.com/repos/citusdata/docker/pulls`;
-
-# Now push another and open a PR against develop
-`git checkout -b release-$VERSION-develop-$curTime`;
-`git push origin release-$VERSION-develop-$curTime`;
-`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump docker to $VERSION\", \"base\":\"develop\", \"head\":\"release-$VERSION-develop-$curTime\"}' https://api.github.com/repos/citusdata/docker/pulls`;


### PR DESCRIPTION
As we are not using develop branch to deploy docker images anymore, it doesn't make sense to open another pr against develop.