### PR TITLE
Make the base branch master instead of develop

### DIFF
--- a/automated_packaging/update_docker.pl
+++ b/automated_packaging/update_docker.pl
@@ -18,7 +18,7 @@ $year += 1900;
 $curTime = time();
 
 # Checkout to the release's branch
-`git checkout develop`;
+`git checkout master`;
 `git checkout -b release-$VERSION-$curTime`;
 
 # That means we want to update postgres version


### PR DESCRIPTION
We already open the pr's to update docker images against master, hence we should not use develop as the base branch.