### PR TITLE
Small improvements in update_pgxn.pl

### DIFF
--- a/automated_packaging/update_pgxn.pl
+++ b/automated_packaging/update_pgxn.pl
@@ -25,11 +25,10 @@ $curTime = time();
 
 # Update META.json file
 `sed -i 's/$old_version_escape_dot/$NEW_VERSION/g' META.json`;
-`sed -i 's/$old_minor_version-[[:digit:]]/$new_minor_version-$new_point_version/g' META.json`;
 
 # Commit changes to github
-`git commit -a -m "Bump Citus to $NEW_VERSION"`;
+`git commit -a -m "Bump Citus PGXN to $NEW_VERSION"`;
 `git push origin pgxn-citus-push-$curTime`;
 
 # Open a PR to the master
-`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump Citus to $NEW_VERSION\", \"base\":\"pgxn-citus\", \"head\":\"pgxn-citus-push-$curTime\"}' https://api.github.com/repos/citusdata/packaging/pulls`;
+`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump Citus PGXN to $NEW_VERSION\", \"base\":\"pgxn-citus\", \"head\":\"pgxn-citus-push-$curTime\"}' https://api.github.com/repos/citusdata/packaging/pulls`;


### PR DESCRIPTION
* As now we are putting a different file (pre-determined) instead of the latest migration script into 
  the pgxn package, remove related `sed` command.
* Update pr title and commit message to be more explicit about we are actually updating pgxn 
  package.

~Note: Will become a full pr after seeing that pgxn 9.3.0 package is deployed properly~