### PR TITLE
Set all automated PRs as draft

### DIFF
--- a/automated_packaging/prepare_changelog.pl
+++ b/automated_packaging/prepare_changelog.pl
@@ -49,4 +49,4 @@ close(CHANGELOG_FILE);
 # Commit and push the changes, then open a PR
 `git commit -a -m "Add changelog entry for $NEW_VERSION"`;
 `git push origin $PROJECT-$NEW_VERSION-changelog-$curTime`;
-`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump $PROJECT to $NEW_VERSION\", \"base\":\"master\", \"head\":\"$PROJECT-$NEW_VERSION-changelog-$curTime\"}' https://api.github.com/repos/citusdata/$PROJECT/pulls`;
+`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump $PROJECT to $NEW_VERSION\", \"base\":\"master\", \"head\":\"$PROJECT-$NEW_VERSION-changelog-$curTime\" \"draft\":True}' https://api.github.com/repos/citusdata/$PROJECT/pulls`;

--- a/automated_packaging/prepare_release.pl
+++ b/automated_packaging/prepare_release.pl
@@ -109,7 +109,7 @@ if ( $NEW_VERSION =~ /.*\.0$/ ) {
     `git add ./src/backend/distributed/citus--$current_schema_version--$upcoming_minor_version-1.sql`;
     `git commit -a -m "Bump $PROJECT version to $UPCOMING_VERSION"`;
     `git push origin master-update-version-$curTime`;
-    `curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump Citus to $UPCOMING_VERSION\", \"base\":\"master\", \"head\":\"master-update-version-$curTime"}' https://api.github.com/repos/citusdata/$PROJECT/pulls`;
+    `curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump Citus to $UPCOMING_VERSION\", \"base\":\"master\", \"head\":\"master-update-version-$curTime" \"draft\":True}' https://api.github.com/repos/citusdata/$PROJECT/pulls`;
 }
 
 # means it is a point version

--- a/automated_packaging/update_docker.pl
+++ b/automated_packaging/update_docker.pl
@@ -60,4 +60,4 @@ close(CHANGELOG);
 # Push the branch and open a PR against master
 `git commit -a -m "Bump to version $VERSION"`;
 `git push origin release-$VERSION-$curTime`;
-`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump docker to $VERSION\", \"base\":\"master\", \"head\":\"release-$VERSION-$curTime\"}' https://api.github.com/repos/citusdata/docker/pulls`;
+`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump docker to $VERSION\", \"base\":\"master\", \"head\":\"release-$VERSION-$curTime\" \"draft\":True}' https://api.github.com/repos/citusdata/docker/pulls`;

--- a/automated_packaging/update_documentation.pl
+++ b/automated_packaging/update_documentation.pl
@@ -26,4 +26,4 @@ $old_release_minor_version_escape_dot =~ s/\./\\./g;
 `git push origin master-$NEW_VERSION-$curTime`;
 
 # Open a PR to the master
-`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump Citus to $NEW_VERSION\", \"base\":\"master\", \"head\":\"master-$NEW_VERSION-$curTime\"}' https://api.github.com/repos/citusdata/citus_docs/pulls`;
+`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump Citus to $NEW_VERSION\", \"base\":\"master\", \"head\":\"master-$NEW_VERSION-$curTime\" \"draft\":True}' https://api.github.com/repos/citusdata/citus_docs/pulls`;

--- a/automated_packaging/update_os_package.pl
+++ b/automated_packaging/update_os_package.pl
@@ -126,4 +126,4 @@ if ($DISTRO_VERSION eq "all") {
 my $commit_message = "Bump $commit_message_distro_version$log_repo_name version to $VERSION";
 `git commit -a -m "$commit_message"`;
 `git push origin $pr_branch`;
-`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"$commit_message\", \"head\":\"$pr_branch\", \"base\":\"$main_branch\"}' https://api.github.com/repos/citusdata/packaging/pulls`;
+`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"$commit_message\", \"head\":\"$pr_branch\", \"base\":\"$main_branch\" \"draft\":True}' https://api.github.com/repos/citusdata/packaging/pulls`;

--- a/automated_packaging/update_pgxn.pl
+++ b/automated_packaging/update_pgxn.pl
@@ -31,4 +31,4 @@ $curTime = time();
 `git push origin pgxn-citus-push-$curTime`;
 
 # Open a PR to the master
-`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump Citus PGXN to $NEW_VERSION\", \"base\":\"pgxn-citus\", \"head\":\"pgxn-citus-push-$curTime\"}' https://api.github.com/repos/citusdata/packaging/pulls`;
+`curl -g -H "Accept: application/vnd.github.v3.full+json" -X POST --user "$github_token:x-oauth-basic" -d '{\"title\":\"Bump Citus PGXN to $NEW_VERSION\", \"base\":\"pgxn-citus\", \"head\":\"pgxn-citus-push-$curTime\" \"draft\":True}' https://api.github.com/repos/citusdata/packaging/pulls`;


### PR DESCRIPTION
When we use the scripts to update branches, and open pull requests there can be issues with the resulting PRs occasionally.

I believe the owner of a packaging task should review all automated PRs and set the PR as ready only after confirming that the contents are fine