### PR TITLE
Add support for Postgres 13

### DIFF
--- a/travis/install_custom_pg
+++ b/travis/install_custom_pg
@@ -17,8 +17,8 @@ if [ "$(ls -A postgresql)" ]; then
   git -C postgresql pull
 else
   pgmajornum="${PGVERSION%%.*}"
-  if [ "${pgmajornum}" -gt '12' ]; then
-    # twelve is highest stable build; use master for higher
+  if [ "${pgmajornum}" -gt '13' ]; then
+    # 13 is highest stable build; use master for higher
     gitref="master"
   elif [ "${pgmajornum}" -gt '9' ]; then
     gitref="REL_${PGVERSION}_STABLE"

--- a/travis/setup_apt
+++ b/travis/setup_apt
@@ -12,11 +12,11 @@ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7FCC7D46ACCC4CF8
 sudo rm -f /etc/apt/sources.list.d/google-chrome*
 sudo rm -f /etc/apt/sources.list.d/pgdg.list
 
-# add the PostgreSQL 12 repository
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 12" >> /etc/apt/sources.list.d/postgresql.list'
+# add the PostgreSQL 13 repository
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 13" >> /etc/apt/sources.list.d/postgresql.list'
 
-# need testing repository after version 12
-if [ "${PGVERSION%%.*}" -gt '12' ]; then
+# need testing repository after version 13
+if [ "${PGVERSION%%.*}" -gt '13' ]; then
     # add a PostgreSQL testing repository
     sudo sh -Ec 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg-testing main ${PGVERSION}" >> /etc/apt/sources.list.d/postgresql.list'
 


### PR DESCRIPTION
This is modeled after d9eb817d1d66d22de561d6d78f389065517b3bde, with
a few less changes because the logic was simplified back then.

Needed for https://github.com/citusdata/pg_auto_failover/pull/297 (which adds Postgres 13 support to pg_auto_failover)