### PR TITLE
Feature: add pgbouncer support to citus_dev

### DIFF
--- a/citus_dev/bash_completion
+++ b/citus_dev/bash_completion
@@ -22,7 +22,7 @@ _citus_dev()
 
     case $cmd in
         make)
-            opts="--size --port --use-ssl --no-extension --mx"
+            opts="--size --port --use-ssl --no-extension --mx --destroy --with-pgbouncer"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=($( compgen -W "${opts}" -- "${cur}"))
             fi
@@ -30,7 +30,7 @@ _citus_dev()
             ;;
 
         start|stop)
-            opts="--port"
+            opts="--port --force"
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=($( compgen -W "${opts}" -- "${cur}"))
             fi

--- a/citus_dev/citus_dev
+++ b/citus_dev/citus_dev
@@ -3,8 +3,9 @@
 
 Usage:
   citus_dev make <name> [--size=<count>] [--port=<port>] [--use-ssl] [--no-extension] [--mx] [--destroy] [--init-with=<sql_file>]
+  citus_dev make <name> [--size=<count>] [--port=<port>] [--use-ssl] [--no-extension] [--mx] [--destroy] [--init-with=<sql_file>] [--with-pgbouncer]
   citus_dev restart <name> [--watch] [--port=<port>]
-  citus_dev (start|stop) <name> [--port=<port>]
+  citus_dev (start|stop) <name> [--port=<port>] [--force]
 
 Options:
   --size=<count>           Number of workers to create when 0 the coordinator will be added as a worker [default: 2]
@@ -15,6 +16,8 @@ Options:
   --mx                     Enable metadata sync for all workers
   --destroy                Destroy any old cluster with the same name
   --init-with=<sql_file>   A SQL script to run after creation of the cluster to set up any necessary tables and data
+  --with-pgbouncer         Setup pgbouncers between worker and coordinator (requires citus enterprise)
+  --force                  Forceful shutdown
 
 """
 from docopt import docopt
@@ -61,15 +64,48 @@ def createNodeCommands(clustername, role, index=None, usessl=False, mx=False):
             "echo \"citus.replication_model = 'streaming'\" >> %s/postgresql.conf" % dir
         )
 
+def createPgBouncerUsers(clustername):
+    username = getpass.getuser()
+    with open(f"{clustername}/users.txt", "w") as f:
+        f.write(f'"{username}" ""')
+
+def createPgBouncerConfig(clustername, port, index):
+    workerPort = port + index + 1
+    bouncerPort = port + index + 101
+    username = getpass.getuser()
+
+    bouncerConfig = f"""
+[databases]
+postgres = host=127.0.0.1 port={workerPort}
+
+[pgbouncer]
+application_name_add_host = 1
+pool_mode = transaction
+listen_port = {bouncerPort}
+listen_addr = *
+auth_type = trust
+auth_file = {clustername}/users.txt
+logfile = worker{index}.pgbouncer.log
+pidfile = {clustername}/worker{index}.pgbouncer.pid
+admin_users = {username}
+stats_users = {username}
+client_tls_key_file = {clustername}/worker{index}/server.key
+client_tls_cert_file = {clustername}/worker{index}/server.crt
+client_tls_sslmode = prefer
+"""
+
+    with open(f"{clustername}/worker{index}.pgbouncer.ini", "w") as f:
+        f.write(bouncerConfig)
+
 
 def main(arguments):
     print(arguments)
     if arguments["make"]:
         if arguments['--destroy']:
             name = arguments["<name>"]
-            for role in getRoles(name):
-                run("pg_ctl stop -D %s/%s || true" % (name, role))
+            stopCluster(name, True)
             run('rm -rf %s' % (name))
+
 
         createNodeCommands(
             arguments["<name>"],
@@ -78,7 +114,13 @@ def main(arguments):
             mx=arguments["--mx"],
         )
 
+        port = int(arguments["--port"])
         size = int(arguments["--size"])
+        pgbouncer = bool(arguments["--with-pgbouncer"])
+        clustername = arguments["<name>"]
+
+        if pgbouncer:
+            createPgBouncerUsers(clustername)
 
         for i in range(size):
             createNodeCommands(
@@ -88,8 +130,8 @@ def main(arguments):
                 usessl=arguments["--use-ssl"],
                 mx=arguments["--mx"],
             )
-
-        port = int(arguments["--port"])
+            if pgbouncer:
+                createPgBouncerConfig(clustername, port, i)
 
         cport = port
         role = "coordinator"
@@ -140,25 +182,35 @@ def main(arguments):
                 'psql -p %d -c "SELECT * from master_get_active_worker_nodes();"'
                 % (port)
             )
+
+        if pgbouncer:
+            # need to start pgbouncers and configure pg_dist_poolinfo
+            for i in range(size):
+                coordinatorPort = port
+                workerPort = port + i + 1 
+                bouncerPort = port + i + 101
+                run(f'pgbouncer -d {clustername}/worker{i}.pgbouncer.ini')
+                run(f"psql -p {coordinatorPort} -c \"INSERT INTO pg_dist_poolinfo SELECT nodeid, 'host=localhost port={bouncerPort}' AS poolinfo FROM pg_dist_node WHERE nodeport = {workerPort};\"")
+
+
         if arguments['--init-with']:
             run('psql -p %d -f %s -v ON_ERROR_STOP=1' % (cport, arguments['--init-with']))
 
     elif arguments["stop"]:
-        name = arguments["<name>"]
-        for role in getRoles(name):
-            run("pg_ctl stop -D %s/%s" % (name, role))
+        clusterName = arguments["<name>"]
+        always = arguments["--force"]
+        stopCluster(clusterName, always)
 
 
     elif arguments["start"]:
-        name = arguments["<name>"]
+        clustername = arguments["<name>"]
         port = int(arguments["--port"])
-        cport = port
-        for role in getRoles(name):
-            run(
-                'pg_ctl start -D %s/%s -o "-p %d" -l %s_logfile'
-                % (name, role, cport, role)
-            )
-            cport += 1
+        for role in getRoles(clustername):
+            run(f'pg_ctl start -D {clustername}/{role} -o "-p {port}" -l {role}_logfile')
+            port += 1
+        for bouncerConfig in getPgBouncerConfigs(clustername):
+            run(f'pgbouncer -d {clustername}/{bouncerConfig}')
+
 
 
     elif arguments["restart"]:
@@ -184,11 +236,41 @@ def main(arguments):
         print("unknown command")
         exit(1)
 
+def getPgBouncerPort(clustername, configfile):
+    with open(f"{clustername}/{configfile}") as f:
+            for line in f.readlines():
+                if line.find("listen_port") >= 0:
+                    lineParts = line.split("=")
+                    return int(lineParts[1])
+
+def stopCluster(clustername, always=False):
+    for bouncerConfig in getPgBouncerConfigs(clustername):
+        bouncerPort = getPgBouncerPort(clustername, bouncerConfig)
+        # the way we shut down pgbouncer always results in an error, so we pipe to true
+        run(f"psql -p {bouncerPort} pgbouncer -c \"SHUTDOWN;\" || true")
+
+    pipeTrue = ""
+    if always:
+        pipeTrue = " || true"
+
+    for role in getRoles(clustername):
+        run(f"pg_ctl stop -D {clustername}/{role} {pipeTrue}")
+
+def getPgBouncerConfigs(clustername):
+    try:
+        bouncerFiles = [f.name for f in os.scandir(clustername) if f.name.find("pgbouncer.ini") >= 0]
+        return bouncerFiles
+    except FileNotFoundError:
+        return []
+
 
 def getRoles(name):
-    roles = [f.name for f in os.scandir(name) if f.is_dir()]
-    roles.sort()
-    return roles
+    try:
+        roles = [f.name for f in os.scandir(name) if f.is_dir()]
+        roles.sort()
+        return roles
+    except FileNotFoundError:
+        return []
 
 
 def pg_libdir():


### PR DESCRIPTION
It is non trivial to setup pgbouncer between the coordinators and the workers. Due to the complexities we experiment little with new features having pgbouncer setup in between.

This patch makes it trivial to have pgbouncer setup. During the creation of the cluster you pass the `--with-pgbouncer` flag. This will write the `pgbouncer` configuration files and starts pgbouncer in daemon mode. It does install the records in `pg_dist_poolinfo`, meaning this can only be used with the Citus enterprise repository as of now.