### PR TITLE
Skip pg13 for el/ol 6

### DIFF
--- a/packaging/citus_package
+++ b/packaging/citus_package
@@ -360,6 +360,14 @@ foreach my $platform (@platforms) {
     mkdir $outputdir;
 
     foreach my $pg (@pg_versions) {
+        if (($os eq "el" or $os eq "ol") and $release eq "6" and $pg eq "pg13")
+        {
+            # CentOS and OracleLinux 6 doesn't have pg13 packages yet
+            # so we dont't have package builder docker images yet.
+            # So skip building distro packages for them.
+            next;
+        }
+
         my @docker_args = (
             'run',
             '--rm',


### PR DESCRIPTION
Proper way to disable pg13 package builds for rpm based distros is to modify `pkgvars` files from `all-x` branches.
However, due to the infrastructure that our tooling uses, it would cost much more.
For simplicity, disable them here.