### PR TITLE
Skip pg13 for some distros in build_x_release scripts too

### DIFF
--- a/travis/build_new_nightly
+++ b/travis/build_new_nightly
@@ -15,7 +15,7 @@ if [ "${TARGET_PLATFORM:-}" = "" ]; then
 fi
 
 PLATFORM_TYPE="$(echo "$TARGET_PLATFORM" | cut -d "/" -f1)"
-PLATFORM_VERSION="$(echo "$TARGET_PLATFORM" | cut -d "/" -f2 | cut -d "/" -f1)"
+PLATFORM_VERSION="$(echo "$TARGET_PLATFORM" | cut -d "/" -f2)"
 pkgauth="${PACKAGECLOUD_API_TOKEN}:"
 hubauth="Authorization: token ${GITHUB_TOKEN}"
 

--- a/travis/build_new_nightly
+++ b/travis/build_new_nightly
@@ -14,7 +14,8 @@ if [ "${TARGET_PLATFORM:-}" = "" ]; then
     exit $badusage
 fi
 
-PLATFORM_TYPE="${TARGET_PLATFORM%%/*}"
+PLATFORM_TYPE="$(echo "$TARGET_PLATFORM" | cut -d "/" -f1)"
+PLATFORM_VERSION="$(echo "$TARGET_PLATFORM" | cut -d "/" -f2 | cut -d "/" -f1)"
 pkgauth="${PACKAGECLOUD_API_TOKEN}:"
 hubauth="Authorization: token ${GITHUB_TOKEN}"
 
@@ -26,7 +27,16 @@ source pkgvars
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.6,10}"
 nightlypg="${nightlypg:-${releasepg}}"
+
 latestpg=$(echo "${nightlypg}" | tr ',' '\n' | sort -t. -k1,1n -k2,2n | tail -n1)
+if [[ "$PLATFORM_TYPE" == "debian" ]] && [[ "$PLATFORM_VERSION" == "jessie" ]]; then
+    # Debian Jessie doesn't have pg13 packages yet, override latestpg
+    latestpg=12
+fi
+if { [[ "$PLATFORM_TYPE" == "el" ]] || [[ "$PLATFORM_TYPE" == "ol" ]]; } && [[ "$PLATFORM_VERSION" == "6" ]]; then
+    # CentOS & OracleLinux 6 don't have pg13 packages yet, override latestpg
+    latestpg=12
+fi
 
 case "${PLATFORM_TYPE}" in
     debian|ubuntu)

--- a/travis/build_new_release
+++ b/travis/build_new_release
@@ -14,8 +14,8 @@ if [ "${TARGET_PLATFORM:-}" = "" ]; then
     exit $badusage
 fi
 
-PLATFORM_TYPE="$(echo "$TARGET_PLATFORM" | cut -d"/" -f1)"
-PLATFORM_VERSION="$(echo "$TARGET_PLATFORM" | cut -d"/" -f2 | cut -d"/" -f1)"
+PLATFORM_TYPE="$(echo "$TARGET_PLATFORM" | cut -d "/" -f1)"
+PLATFORM_VERSION="$(echo "$TARGET_PLATFORM" | cut -d "/" -f2)"
 pkgauth="${PACKAGECLOUD_API_TOKEN}:"
 
 # populate variables from packaging metadata file

--- a/travis/build_new_release
+++ b/travis/build_new_release
@@ -14,7 +14,8 @@ if [ "${TARGET_PLATFORM:-}" = "" ]; then
     exit $badusage
 fi
 
-PLATFORM_TYPE="${TARGET_PLATFORM%%/*}"
+PLATFORM_TYPE="$(echo "$TARGET_PLATFORM" | cut -d"/" -f1)"
+PLATFORM_VERSION="$(echo "$TARGET_PLATFORM" | cut -d"/" -f2 | cut -d"/" -f1)"
 pkgauth="${PACKAGECLOUD_API_TOKEN}:"
 
 # populate variables from packaging metadata file
@@ -26,7 +27,17 @@ declare pkglatest # to make shellcheck happy
 nightlyref="${nightlyref:-master}"
 releasepg="${releasepg:-9.6,10}"
 nightlypg="${nightlypg:-}"
+
 latestpg=$(echo "${releasepg}" | tr ',' '\n' | sort -t. -k1,1n -k2,2n | tail -n1)
+if [[ "$PLATFORM_TYPE" == "debian" ]] && [[ "$PLATFORM_VERSION" == "jessie" ]]; then
+    # Debian Jessie doesn't have pg13 packages yet, override latestpg
+    latestpg=12
+fi
+if { [[ "$PLATFORM_TYPE" == "el" ]] || [[ "$PLATFORM_TYPE" == "ol" ]]; } && [[ "$PLATFORM_VERSION" == "6" ]]; then
+    # CentOS & OracleLinux 6 don't have pg13 packages yet, override latestpg
+    latestpg=12
+fi
+
 versioning="${versioning:-simple}"
 
 case "${PLATFORM_TYPE}" in


### PR DESCRIPTION
Complete the changes done in https://github.com/citusdata/tools/pull/82.

Previously, as `latestpg` that our scripts think that we should have in PackageCloud becomes 13 so script was trying to push nightly images.
However, as they already exists in PackageCloud, ci was reporting error.