### PR TITLE
Package cloud statistics  download cron schedule fix

### DIFF
--- a/.github/workflows/package-cloud-download-schedule.yml
+++ b/.github/workflows/package-cloud-download-schedule.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 jobs:
 
-  unit_test_execution:
+  statistics_fetch:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -21,6 +21,7 @@ jobs:
         parallel_index: [
             0,1,2,3,4,5,6,7,8,9
         ]
+        repo: [community,enterprise,community_nightlies,enterprise_nightlies]
 
     steps:
       - name: Checkout repository
@@ -35,7 +36,7 @@ jobs:
       - name: Execute 'Package Cloud Statistics Collector'
         run: |
               python -m packaging_automation.package_cloud_statistics_collector --organization citusdata --repo_name \
-              citus --db_user_name ${{ secrets.STATS_DB_USER_NAME }} --db_password ${{ secrets.STATS_DB_PASSWORD }} \
+              ${{ matrix.repo }} --db_user_name ${{ secrets.STATS_DB_USER_NAME }} --db_password ${{ secrets.STATS_DB_PASSWORD }} \
               --db_host_and_port ${{ secrets.STATS_DB_HOST_AND_PORT }} --db_name ${{ secrets.STATS_DB_NAME }} \
               --package_cloud_api_token ${{ secrets.PACKAGE_CLOUD_API_TOKEN }} --parallel_count 10 \
               --parallel_exec_index ${{ matrix.parallel_index }} --page_record_count 100

--- a/packaging_automation/package_cloud_statistics_collector.py
+++ b/packaging_automation/package_cloud_statistics_collector.py
@@ -9,7 +9,6 @@ from typing import List, Any
 import requests
 from sqlalchemy import Column, INTEGER, DATE, TIMESTAMP, String
 
-from release.docker.tools.packaging_automation.package_cloud_statistics_collector import PackageCloudRepos
 from .common_tool_methods import (remove_suffix, stat_get_request)
 from .dbconfig import (Base, db_session, DbParams, RequestType)
 
@@ -108,7 +107,7 @@ def fetch_and_save_package_stats_for_package_list(package_info_list: List[Any], 
                                                                          package_info['filename'],
                                                                          session) and (
                     is_download_count_eligible_for_save(download_count, save_records_with_download_count_zero)):
-                pc_stats = PackageCloudDownloadStats(fetch_date=datetime.now(), repo=repo_name.name,
+                pc_stats = PackageCloudDownloadStats(fetch_date=datetime.now(), repo=repo_name.value,
                                                      package_full_name=package_info['filename'],
                                                      package_name=package_info['name'],
                                                      package_version=package_info['version'],

--- a/packaging_automation/package_cloud_statistics_collector.py
+++ b/packaging_automation/package_cloud_statistics_collector.py
@@ -9,6 +9,7 @@ from typing import List, Any
 import requests
 from sqlalchemy import Column, INTEGER, DATE, TIMESTAMP, String
 
+from release.docker.tools.packaging_automation.package_cloud_statistics_collector import PackageCloudRepos
 from .common_tool_methods import (remove_suffix, stat_get_request)
 from .dbconfig import (Base, db_session, DbParams, RequestType)
 
@@ -90,7 +91,7 @@ def fetch_and_save_package_cloud_stats(db_params: DbParams, package_cloud_api_to
 
 
 def fetch_and_save_package_stats_for_package_list(package_info_list: List[Any], package_cloud_api_token: str, session,
-                                                  save_records_with_download_count_zero: bool, repo_name: str):
+                                                  save_records_with_download_count_zero: bool, repo_name: PackageCloudRepos):
     '''Gets and saves the package statistics of the given packages'''
     for package_info in package_info_list:
 
@@ -107,7 +108,7 @@ def fetch_and_save_package_stats_for_package_list(package_info_list: List[Any], 
                                                                          package_info['filename'],
                                                                          session) and (
                     is_download_count_eligible_for_save(download_count, save_records_with_download_count_zero)):
-                pc_stats = PackageCloudDownloadStats(fetch_date=datetime.now(), repo=repo_name,
+                pc_stats = PackageCloudDownloadStats(fetch_date=datetime.now(), repo=repo_name.name,
                                                      package_full_name=package_info['filename'],
                                                      package_name=package_info['name'],
                                                      package_version=package_info['version'],

--- a/packaging_automation/package_cloud_statistics_collector.py
+++ b/packaging_automation/package_cloud_statistics_collector.py
@@ -8,6 +8,7 @@ from typing import List, Any
 
 import requests
 from sqlalchemy import Column, INTEGER, DATE, TIMESTAMP, String
+import sqlalchemy
 
 from .common_tool_methods import (remove_suffix, stat_get_request)
 from .dbconfig import (Base, db_session, DbParams, RequestType)
@@ -34,7 +35,7 @@ class PackageCloudDownloadStats(Base):
     __tablename__ = "package_cloud_download_stats"
     id = Column(INTEGER, primary_key=True, autoincrement=True)
     fetch_date = Column(TIMESTAMP, nullable=False)
-    repo = Column(Enum(PackageCloudRepos), nullable=False)
+    repo = Column(sqlalchemy.Enum(PackageCloudRepos), nullable=False)
     package_name = Column(String, nullable=False)
     package_full_name = Column(String, nullable=False)
     package_version = Column(String, nullable=False)
@@ -108,7 +109,7 @@ def fetch_and_save_package_stats_for_package_list(package_info_list: List[Any], 
                                                                          package_info['filename'],
                                                                          session) and (
                     is_download_count_eligible_for_save(download_count, save_records_with_download_count_zero)):
-                pc_stats = PackageCloudDownloadStats(fetch_date=datetime.now(), repo=repo_name.value,
+                pc_stats = PackageCloudDownloadStats(fetch_date=datetime.now(), repo=repo_name,
                                                      package_full_name=package_info['filename'],
                                                      package_name=package_info['name'],
                                                      package_version=package_info['version'],

--- a/packaging_automation/package_cloud_statistics_collector.py
+++ b/packaging_automation/package_cloud_statistics_collector.py
@@ -34,6 +34,7 @@ class PackageCloudDownloadStats(Base):
     __tablename__ = "package_cloud_download_stats"
     id = Column(INTEGER, primary_key=True, autoincrement=True)
     fetch_date = Column(TIMESTAMP, nullable=False)
+    repo = Column(String, nullable=False)
     package_name = Column(String, nullable=False)
     package_full_name = Column(String, nullable=False)
     package_version = Column(String, nullable=False)
@@ -80,7 +81,7 @@ def fetch_and_save_package_cloud_stats(db_params: DbParams, package_cloud_api_to
         else:
             break
         fetch_and_save_package_stats_for_package_list(package_info_list, package_cloud_api_token, session,
-                                                      save_records_with_download_count_zero)
+                                                      save_records_with_download_count_zero, repo_name)
 
         session.commit()
     end = time.time()
@@ -89,7 +90,7 @@ def fetch_and_save_package_cloud_stats(db_params: DbParams, package_cloud_api_to
 
 
 def fetch_and_save_package_stats_for_package_list(package_info_list: List[Any], package_cloud_api_token: str, session,
-                                                  save_records_with_download_count_zero: bool):
+                                                  save_records_with_download_count_zero: bool, repo_name: str):
     '''Gets and saves the package statistics of the given packages'''
     for package_info in package_info_list:
 
@@ -106,7 +107,7 @@ def fetch_and_save_package_stats_for_package_list(package_info_list: List[Any], 
                                                                          package_info['filename'],
                                                                          session) and (
                     is_download_count_eligible_for_save(download_count, save_records_with_download_count_zero)):
-                pc_stats = PackageCloudDownloadStats(fetch_date=datetime.now(),
+                pc_stats = PackageCloudDownloadStats(fetch_date=datetime.now(), repo=repo_name,
                                                      package_full_name=package_info['filename'],
                                                      package_name=package_info['name'],
                                                      package_version=package_info['version'],

--- a/packaging_automation/package_cloud_statistics_collector.py
+++ b/packaging_automation/package_cloud_statistics_collector.py
@@ -34,7 +34,7 @@ class PackageCloudDownloadStats(Base):
     __tablename__ = "package_cloud_download_stats"
     id = Column(INTEGER, primary_key=True, autoincrement=True)
     fetch_date = Column(TIMESTAMP, nullable=False)
-    repo = Column(String, nullable=False)
+    repo = Column(Enum(PackageCloudRepos), nullable=False)
     package_name = Column(String, nullable=False)
     package_full_name = Column(String, nullable=False)
     package_version = Column(String, nullable=False)
@@ -90,7 +90,8 @@ def fetch_and_save_package_cloud_stats(db_params: DbParams, package_cloud_api_to
 
 
 def fetch_and_save_package_stats_for_package_list(package_info_list: List[Any], package_cloud_api_token: str, session,
-                                                  save_records_with_download_count_zero: bool, repo_name: PackageCloudRepos):
+                                                  save_records_with_download_count_zero: bool,
+                                                  repo_name: PackageCloudRepos):
     '''Gets and saves the package statistics of the given packages'''
     for package_info in package_info_list:
 


### PR DESCRIPTION
There is a problem in Package Cloud Statistics Download Cron schedule as below. This PR fixes invalid repo names in schedule pipeline and adds a repo name column into statistics table.
https://github.com/citusdata/tools/actions/runs/1088494331