### PR TITLE
update_package_properties pipeline branch problem

### DIFF
--- a/packaging_automation/update_package_properties.py
+++ b/packaging_automation/update_package_properties.py
@@ -349,5 +349,4 @@ if __name__ == "__main__":
         run(f'git push --set-upstream origin {pr_branch}')
         create_pr(arguments.gh_token, pr_branch, commit_message, REPO_OWNER, PROJECT_NAME,
                   project.value.packaging_branch)
-        if not arguments.pipeline:
-            remove_cloned_code(execution_path)
+        remove_cloned_code(execution_path)

--- a/packaging_automation/update_package_properties.py
+++ b/packaging_automation/update_package_properties.py
@@ -349,4 +349,5 @@ if __name__ == "__main__":
         run(f'git push --set-upstream origin {pr_branch}')
         create_pr(arguments.gh_token, pr_branch, commit_message, REPO_OWNER, PROJECT_NAME,
                   project.value.packaging_branch)
-        remove_cloned_code(execution_path)
+        if not arguments.pipeline:
+            remove_cloned_code(execution_path)

--- a/packaging_automation/update_package_properties.py
+++ b/packaging_automation/update_package_properties.py
@@ -320,10 +320,11 @@ if __name__ == "__main__":
     else:
         execution_path = f"{os.getcwd()}/{CHECKOUT_DIR}"
         initialize_env(execution_path, PROJECT_NAME, execution_path)
+        run(f"git checkout {project.value.packaging_branch}")
 
     os.chdir(execution_path)
 
-    run(f"git checkout {project.value.packaging_branch}")
+
     pr_branch = f"{project.value.packaging_branch}-{prj_ver}-{uuid.uuid4()}"
     run(f"git checkout -b {pr_branch}")
     if arguments.date:
@@ -348,4 +349,5 @@ if __name__ == "__main__":
         run(f'git push --set-upstream origin {pr_branch}')
         create_pr(arguments.gh_token, pr_branch, commit_message, REPO_OWNER, PROJECT_NAME,
                   project.value.packaging_branch)
-        remove_cloned_code(execution_path)
+        if not arguments.pipeline:
+            remove_cloned_code(execution_path)

--- a/packaging_automation/update_pgxn.py
+++ b/packaging_automation/update_pgxn.py
@@ -63,5 +63,4 @@ if __name__ == "__main__":
     if not args.is_test:
         run(f'git push --set-upstream origin {pr_branch}')
         create_pr(github_token, pr_branch, commit_message, REPO_OWNER, PROJECT_NAME, main_branch)
-        if not args.pipeline:
-            remove_cloned_code(execution_path)
+        remove_cloned_code(execution_path)


### PR DESCRIPTION
update_package_properties script can be executed both manually and in pipeline. While executing in pipeline, all branches are not closed so checking out the main packaging branch (e.g. ell-citus) causes problem in PR branches since all-citus is not fetched at the time of pipeline execution.
Checking out handled if pipeline flag is set and also code deletion is done in manual execution case i.e. when pipeline is false

Fixes #149