### PR TITLE
Adds flag to docker run to be able to build pg14 packages

### DIFF
--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -218,9 +218,13 @@ def build_package(github_token: non_empty(non_blank(str)),
         os.makedirs(input_output_parameters.output_dir)
 
     output = run_with_output(
-        f"docker run --rm -v {input_output_parameters.output_dir}:/packages -v {input_output_parameters.input_files_dir}:/buildfiles:ro -e "
-        f"GITHUB_TOKEN -e PACKAGE_ENCRYPTION_KEY -e UNENCRYPTED_PACKAGE "
-        f"citus/packaging:{docker_platform}-{postgres_extension} {build_type.name}", text=True)
+        f'docker run --rm -v {input_output_parameters.output_dir}:/packages -v '
+        f'{input_output_parameters.input_files_dir}:/buildfiles:ro -e '
+        f'GITHUB_TOKEN -e PACKAGE_ENCRYPTION_KEY -e UNENCRYPTED_PACKAGE '
+        # TODO The below line should be deleted after PG14 official release
+        # This line is to override pg_buildext supported PG releases
+        f'-e DEB_PG_SUPPORTED_VERSIONS="10\n11\n12\n13\n14"'  
+        f'citus/packaging:{docker_platform}-{postgres_extension} {build_type.name}', text=True)
 
     if output.stdout:
         print("Output:" + output.stdout)

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -223,7 +223,7 @@ def build_package(github_token: non_empty(non_blank(str)),
         f'GITHUB_TOKEN -e PACKAGE_ENCRYPTION_KEY -e UNENCRYPTED_PACKAGE '
         # TODO The below line should be deleted after PG14 official release
         # This line is to override pg_buildext supported PG releases
-        f'-e DEB_PG_SUPPORTED_VERSIONS="10\n11\n12\n13\n14"'  
+        f'-e DEB_PG_SUPPORTED_VERSIONS="10\n11\n12\n13\n14" '  
         f'citus/packaging:{docker_platform}-{postgres_extension} {build_type.name}', text=True)
 
     if output.stdout:


### PR DESCRIPTION
Since pg14 is not released yet we need to add extra flag to be able to add pg 14 support. I added 10 and 11 to support some back releases of citus (9.3 etc). 