### PR TITLE
Fixes current branch check problem when tag is pushed to push docker tags

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Define git credentials
         run: git config --global user.email "${MICROSOFT_EMAIL}"&& git config --global user.name "${USER_NAME}"

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run static code analysis
         run: python -m prospector
 
+      - name: Unit tests for "Common tools"
+        run: python -m pytest -q packaging_automation/tests/test_common_tool_methods.py
+
       - name: Unit tests for "Update Package Properties"
         run: python -m pytest -q packaging_automation/tests/test_update_package_properties.py
 
@@ -55,9 +58,6 @@ jobs:
 
       - name: Unit tests for "Update Pgxn"
         run: python -m pytest -q packaging_automation/tests/test_update_pgxn.py
-
-      - name: Unit tests for "Common tools"
-        run: python -m pytest -q packaging_automation/tests/test_common_tool_methods.py
 
       - name: Packaging Warning Handler
         run: python -m pytest -q packaging_automation/tests/test_packaging_warning_handler.py

--- a/packaging_automation/common_tool_methods.py
+++ b/packaging_automation/common_tool_methods.py
@@ -1,19 +1,17 @@
-import base64
 import os
 import re
 import shlex
 import subprocess
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List
-from typing import Tuple
+from typing import Dict, List,Tuple
 
+import git
 import gnupg
 import pathlib2
 import requests
-from git import Repo, GitCommandError
-import git
-from github import Repository, PullRequest, Commit, Github
+from git import GitCommandError,Repo
+from github import Commit, Github, PullRequest,Repository
 from jinja2 import Environment, FileSystemLoader
 from parameters_validation import validate_parameters
 

--- a/packaging_automation/common_tool_methods.py
+++ b/packaging_automation/common_tool_methods.py
@@ -4,14 +4,15 @@ import shlex
 import subprocess
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List,Tuple
+from typing import Dict, List, Tuple
 
+import base64
 import git
 import gnupg
 import pathlib2
 import requests
-from git import GitCommandError,Repo
-from github import Commit, Github, PullRequest,Repository
+from git import GitCommandError, Repo
+from github import Commit, Github, PullRequest, Repository
 from jinja2 import Environment, FileSystemLoader
 from parameters_validation import validate_parameters
 

--- a/packaging_automation/common_tool_methods.py
+++ b/packaging_automation/common_tool_methods.py
@@ -306,12 +306,14 @@ def is_tag_on_branch(tag_name: str, branch_name: str):
     try:
         branches_str = g.execute(["git", "branch", "--contains", f"tags/{tag_name}"])
         branches = remove_prefix(branches_str, "*").split("\n")
+        print("Branches str:" + branches_str)
         if len(branches) > 0:
             for branch in branches:
                 if branch.strip() == branch_name:
                     return True
         return False
-    except GitCommandError:
+    except GitCommandError as e:
+        print("Error:" + str(e))
         return False
 
 

--- a/packaging_automation/common_tool_methods.py
+++ b/packaging_automation/common_tool_methods.py
@@ -11,7 +11,7 @@ from typing import Tuple
 import gnupg
 import pathlib2
 import requests
-from git import Repo,GitCommandError
+from git import Repo, GitCommandError
 import git
 from github import Repository, PullRequest, Commit, Github
 from jinja2 import Environment, FileSystemLoader
@@ -300,6 +300,7 @@ def prepend_line_in_file(file: str, match_regex: str, append_str: str) -> bool:
 
     return has_match
 
+
 def is_tag_on_branch(tag_name: str, branch_name: str):
     g = git.Git(os.getcwd())
     try:
@@ -314,15 +315,10 @@ def is_tag_on_branch(tag_name: str, branch_name: str):
         return False
 
 
-
-
 def get_current_branch(working_dir: str) -> str:
     repo = get_new_repo(working_dir)
-    try:
-        branch_name = repo.active_branch.name
-    except TypeError:
-        branch_name = 'Detached'
-    return branch_name
+
+    return repo.active_branch.name
 
 
 def remote_branch_exists(branch_name: str, working_dir: str) -> bool:

--- a/packaging_automation/publish_docker.py
+++ b/packaging_automation/publish_docker.py
@@ -149,9 +149,6 @@ def publish_tagged_docker_images(docker_image_type, tag_name: str, publish: bool
     docker_client.images.build(dockerfile=docker_image_info_dict[docker_image_type]['file-name'],
                                tag=docker_image_name,
                                path=".")
-    if not publish:
-        print(f"Tags will not be pushed since publish flag is false.  ")
-        return
     print(f"{docker_image_type.name} image built.Now starting tagging and pushing...")
     for tag_part in tag_parts:
         tag_version_part = tag_version_part + tag_part
@@ -159,10 +156,12 @@ def publish_tagged_docker_images(docker_image_type, tag_name: str, publish: bool
         print(f"Tagging {docker_image_name} with the tag {image_tag}...")
         docker_api_client.tag(docker_image_name, docker_image_name, image_tag)
         print(f"Tagging {docker_image_name} with the tag {image_tag} finished.")
-
-        print(f"Pushing {docker_image_name} with the tag {image_tag}...")
-        docker_client.images.push(DOCKER_IMAGE_NAME, tag=image_tag)
-        print(f"Pushing {docker_image_name} with the tag {image_tag} finished")
+        if publish:
+            print(f"Pushing {docker_image_name} with the tag {image_tag}...")
+            docker_client.images.push(DOCKER_IMAGE_NAME, tag=image_tag)
+            print(f"Pushing {docker_image_name} with the tag {image_tag} finished")
+        else:
+            print(f"Skipped pushing {docker_image_type} with the tag {image_tag} since publish flag is false")
 
         tag_version_part = tag_version_part + "."
     print(f"Building and publishing tagged image {docker_image_type.name} for tag {tag_name} finished.")

--- a/packaging_automation/publish_docker.py
+++ b/packaging_automation/publish_docker.py
@@ -7,7 +7,7 @@ import docker
 import pathlib2
 from parameters_validation import validate_parameters
 
-from .common_tool_methods import remove_prefix, get_current_branch
+from .common_tool_methods import remove_prefix, get_current_branch, is_tag_on_branch
 from .common_validations import is_tag
 
 BASE_PATH = pathlib2.Path(__file__).parents[1]
@@ -147,8 +147,9 @@ def publish_tagged_docker_images(docker_image_type, tag_name: str, current_branc
     docker_client.images.build(dockerfile=docker_image_info_dict[docker_image_type]['file-name'],
                                tag=docker_image_name,
                                path=".")
-    if current_branch != DEFAULT_BRANCH_NAME:
-        print(f"Since current branch {current_branch} is not equal to {DEFAULT_BRANCH_NAME} tags will not be pushed.")
+    if is_tag_on_branch(tag_name=tag_name, branch_name=DEFAULT_BRANCH_NAME):
+        print(f"Since default branch {DEFAULT_BRANCH_NAME} does not contain {tag_parts} ,tags will not be pushed.")
+        return
     print(f"{docker_image_type.name} image built.Now starting tagging and pushing...")
     for tag_part in tag_parts:
         tag_version_part = tag_version_part + tag_part

--- a/packaging_automation/publish_docker.py
+++ b/packaging_automation/publish_docker.py
@@ -226,8 +226,7 @@ def get_image_publish_status(github_ref: str, is_test: bool):
     if triggering_event_info == GithubTriggerEventSource.tag_push:
         if not is_tag_on_branch(tag_name=resource_name, branch_name=DEFAULT_BRANCH_NAME):
             return False
-        else:
-            return True
+        return True
     current_branch = get_current_branch(os.getcwd())
     if current_branch != DEFAULT_BRANCH_NAME:
         return False

--- a/packaging_automation/publish_docker.py
+++ b/packaging_automation/publish_docker.py
@@ -54,7 +54,7 @@ docker_image_info_dict = {
                                   "schedule-type": ScheduleType.regular},
     DockerImageType.nightly: {"file-name": "nightly/Dockerfile", "docker-tag": "nightly",
                               "schedule-type": ScheduleType.nightly}}
-DOCKER_IMAGE_NAME = "gurkanindibay/citus"
+DOCKER_IMAGE_NAME = "citusdata/citus"
 
 docker_client = docker.from_env()
 

--- a/packaging_automation/publish_docker.py
+++ b/packaging_automation/publish_docker.py
@@ -117,7 +117,7 @@ def publish_docker_image_manually(manual_trigger_type_param: ManualTriggerType, 
             publish_main_docker_images(it, will_be_published)
     elif manual_trigger_type_param == ManualTriggerType.tags and tag_name:
         for it in regular_images_to_be_built(docker_image_type):
-            publish_tagged_docker_images(it, tag_name)
+            publish_tagged_docker_images(it, tag_name, will_be_published)
     elif manual_trigger_type_param == ManualTriggerType.nightly:
         publish_nightly_docker_image(will_be_published)
 

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -8,15 +8,34 @@ from github import Github
 
 from .test_utils import generate_new_gpg_key
 from ..common_tool_methods import (
-    find_nth_occurrence_position, is_major_release,
-    str_array_to_str, run, remove_text_with_parenthesis, get_version_details,
-    replace_line_in_file, get_upcoming_minor_version,
-    get_project_version_from_tag_name, find_nth_matching_line_and_line_number, get_minor_version,
-    get_patch_version_regex, append_line_in_file, prepend_line_in_file, remote_branch_exists, get_current_branch,
-    local_branch_exists, get_last_commit_message, get_prs_for_patch_release, filter_prs_by_label, process_template_file,
-    remove_prefix, delete_all_gpg_keys_by_name, define_rpm_public_key_to_machine,
-    delete_rpm_key_by_name, get_gpg_fingerprints_by_name, run_with_output, rpm_key_matches_summary,
-    DEFAULT_ENCODING_FOR_FILE_HANDLING, DEFAULT_UNICODE_ERROR_HANDLER, is_tag_on_branch)
+    DEFAULT_ENCODING_FOR_FILE_HANDLING,
+    DEFAULT_UNICODE_ERROR_HANDLER,
+    append_line_in_file,
+    define_rpm_public_key_to_machine,
+    delete_all_gpg_keys_by_name,
+    delete_rpm_key_by_name,
+    filter_prs_by_label,
+    find_nth_matching_line_and_line_number,
+    find_nth_occurrence_position,
+    get_current_branch,
+    get_gpg_fingerprints_by_name,
+    get_last_commit_message,
+    get_minor_version,
+    get_patch_version_regex,
+    get_project_version_from_tag_name,
+    get_prs_for_patch_release,
+    get_upcoming_minor_version, get_version_details,
+    is_major_release,
+    is_tag_on_branch,
+    local_branch_exists,
+    prepend_line_in_file,
+    process_template_file,
+    remote_branch_exists,
+    remove_prefix,
+    remove_text_with_parenthesis,
+    replace_line_in_file,
+    rpm_key_matches_summary,
+    run, run_with_output, str_array_to_str)
 
 GITHUB_TOKEN = os.getenv("GH_TOKEN")
 BASE_PATH = pathlib2.Path(__file__).parents[1]

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -16,7 +16,7 @@ from ..common_tool_methods import (
     local_branch_exists, get_last_commit_message, get_prs_for_patch_release, filter_prs_by_label, process_template_file,
     remove_prefix, delete_all_gpg_keys_by_name, define_rpm_public_key_to_machine,
     delete_rpm_key_by_name, get_gpg_fingerprints_by_name, run_with_output, rpm_key_matches_summary,
-    DEFAULT_ENCODING_FOR_FILE_HANDLING, DEFAULT_UNICODE_ERROR_HANDLER)
+    DEFAULT_ENCODING_FOR_FILE_HANDLING, DEFAULT_UNICODE_ERROR_HANDLER, is_tag_on_branch)
 
 GITHUB_TOKEN = os.getenv("GH_TOKEN")
 BASE_PATH = pathlib2.Path(__file__).parents[1]
@@ -58,6 +58,11 @@ def test_remove_paranthesis_from_string():
 
 def test_get_version_details():
     assert get_version_details("10.0.1") == {"major": "10", "minor": "0", "patch": "1"}
+
+
+def test_is_tag_on_branch():
+    assert is_tag_on_branch("v0.8.3", "develop")
+    assert not is_tag_on_branch("v1.8.3", "develop")
 
 
 def test_replace_line_in_file():

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -61,8 +61,11 @@ def test_get_version_details():
 
 
 def test_is_tag_on_branch():
+    current_branch = get_current_branch(os.getcwd())
+    run("git checkout develop")
     assert is_tag_on_branch("v0.8.3", "develop")
     assert not is_tag_on_branch("v1.8.3", "develop")
+    run(f"git checkout {current_branch}")
 
 
 def test_replace_line_in_file():

--- a/packaging_automation/tests/test_publish_docker.py
+++ b/packaging_automation/tests/test_publish_docker.py
@@ -55,7 +55,7 @@ def test_publish_main_docker_images():
 
     try:
         run_with_output("git checkout -b docker-unit-test")
-        publish_main_docker_images(DockerImageType.latest, EXEC_PATH)
+        publish_main_docker_images(DockerImageType.latest, False)
         docker_client.images.get("citusdata/citus:latest")
     finally:
         run_with_output("git checkout master")
@@ -67,7 +67,7 @@ def test_publish_tagged_docker_images_latest():
     os.chdir("docker")
     try:
         run_with_output("git checkout -b docker-unit-test")
-        publish_tagged_docker_images(DockerImageType.latest, TAG_NAME, EXEC_PATH)
+        publish_tagged_docker_images(DockerImageType.latest, "v10.0.3", False)
         docker_client.images.get("citusdata/citus:10")
         docker_client.images.get("citusdata/citus:10.0")
         docker_client.images.get("citusdata/citus:10.0.3")
@@ -81,7 +81,7 @@ def test_publish_tagged_docker_images_alpine():
     os.chdir("docker")
     try:
         run_with_output("git checkout -b docker-unit-test")
-        publish_tagged_docker_images(DockerImageType.alpine, TAG_NAME, EXEC_PATH)
+        publish_tagged_docker_images(DockerImageType.alpine, TAG_NAME, False)
         docker_client.images.get("citusdata/citus:10-alpine")
         docker_client.images.get("citusdata/citus:10.0-alpine")
         docker_client.images.get("citusdata/citus:10.0.3-alpine")
@@ -95,13 +95,11 @@ def test_publish_nightly_docker_image():
     os.chdir("docker")
     try:
         run_with_output("git checkout -b docker-unit-test")
-        publish_nightly_docker_image(NON_DEFAULT_BRANCH_NAME)
+        publish_nightly_docker_image(False)
         docker_client.images.get("citusdata/citus:nightly")
     finally:
         run_with_output("git checkout master")
         run_with_output("git branch -D docker-unit-test")
-
-
 
 
 def clear_env():


### PR DESCRIPTION
After building main docker images, we need to create tagged docker images such as 10.0-alpine by creating new tag on master branch
While tagging, Github Actions clones the code in detached state and when in this state we can not get current branch . Since we are using current branch to decide whether images weill published or not, and we can not use it in tag push case , we need to put tag existence case on master branch to be able to handle tag push case
Som improvements are suggested. These are in the issue below
https://github.com/citusdata/tools/issues/192