### PR TITLE
Changes Docker 13 as latest docker image

### DIFF
--- a/packaging_automation/publish_docker.py
+++ b/packaging_automation/publish_docker.py
@@ -29,7 +29,7 @@ class DockerImageType(Enum):
     alpine = 2
     nightly = 3
     postgres_12 = 4
-    postgres_13 = 5
+    postgres_14 = 5
 
 
 class ManualTriggerType(Enum):
@@ -50,7 +50,7 @@ docker_image_info_dict = {
                              "schedule-type": ScheduleType.regular},
     DockerImageType.postgres_12: {"file-name": "postgres-12/Dockerfile", "docker-tag": "pg12",
                                   "schedule-type": ScheduleType.regular},
-    DockerImageType.postgres_13: {"file-name": "postgres-13/Dockerfile", "docker-tag": "pg13",
+    DockerImageType.postgres_14: {"file-name": "postgres-14/Dockerfile", "docker-tag": "pg14",
                                   "schedule-type": ScheduleType.regular},
     DockerImageType.nightly: {"file-name": "nightly/Dockerfile", "docker-tag": "nightly",
                               "schedule-type": ScheduleType.nightly}}


### PR DESCRIPTION
latest docker image is pg 13 until postgres is live. This PR maintains this aim