### PR TITLE
Removes releasepg and nightlypg from pkgvars

### DIFF
--- a/packaging_automation/templates/citus-enterprise-pkgvars.tmpl
+++ b/packaging_automation/templates/citus-enterprise-pkgvars.tmpl
@@ -1,7 +1,5 @@
 pkgname=citus-enterprise
 pkgdesc='Citus Enterprise'
 pkglatest={{version}}
-releasepg=11,12,13
-nightlypg=11,12,13
 nightlyref=enterprise-master
 versioning=fancy

--- a/packaging_automation/templates/citus-pkgvars.tmpl
+++ b/packaging_automation/templates/citus-pkgvars.tmpl
@@ -1,6 +1,4 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
 pkglatest={{version}}
-releasepg=11,12,13
-nightlypg=12,13
 versioning=fancy

--- a/packaging_automation/templates/pg-auto-failover-enterprise-pkgvars.tmpl
+++ b/packaging_automation/templates/pg-auto-failover-enterprise-pkgvars.tmpl
@@ -3,5 +3,4 @@ deb_pkgname=auto-failover-enterprise
 hubproj=citus-ha
 pkgdesc='Postgres extension for automated failover and high-availability'
 pkglatest={{version}}
-releasepg=10,11,12,13
 versioning=fancy

--- a/packaging_automation/templates/pg-auto-failover-pkgvars.tmpl
+++ b/packaging_automation/templates/pg-auto-failover-pkgvars.tmpl
@@ -3,5 +3,4 @@ deb_pkgname=auto-failover
 hubproj=pg_auto_failover
 pkgdesc='Postgres extension for automated failover and high-availability'
 pkglatest={{version}}
-releasepg=10,11,12,13
 versioning=fancy

--- a/packaging_automation/templates/pgxn/pkgvars.tmpl
+++ b/packaging_automation/templates/pgxn/pkgvars.tmpl
@@ -1,4 +1,3 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
 pkglatest={{project_version}}
-releasepg=11,12,13

--- a/packaging_automation/tests/files/pkgvars
+++ b/packaging_automation/tests/files/pkgvars
@@ -1,6 +1,4 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
 pkglatest=10.0.2-1
-releasepg=11,12,13
-nightlypg=12,13
 versioning=fancy

--- a/packaging_automation/tests/files/verify/expected_pkgvars_10.0.3.txt
+++ b/packaging_automation/tests/files/verify/expected_pkgvars_10.0.3.txt
@@ -1,6 +1,4 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
 pkglatest=10.0.3
-releasepg=11,12,13
-nightlypg=12,13
 versioning=fancy

--- a/packaging_automation/tests/test_update_pgxn.py
+++ b/packaging_automation/tests/test_update_pgxn.py
@@ -41,4 +41,4 @@ def test_update_pkgvars():
         content = reader.read()
         lines = content.splitlines()
         assert lines[2] == f'pkglatest={PROJECT_VERSION}'
-        assert len(lines) == 4
+        assert len(lines) == 3


### PR DESCRIPTION
After activating postgres_matrix there is no need to pkgvars postgres version parameters so I removed them from our templates and unit test files 