### PR TITLE
Introduce enterprise_merge tool for automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export mandir := $(datarootdir)/man
 export sysconfdir := $(prefix)/etc
 export pkgsysconfdir := $(sysconfdir)/$(PACKAGE_NAME)
 
-DIRNAMES = automated_packaging packaging uncrustify valgrind
+DIRNAMES = automated_packaging enterprise_merge packaging uncrustify valgrind
 ifeq ($(TRAVIS), true)
 	DIRNAMES += travis
 endif

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Tools and configuration common to multiple Citus Data projects.
 
 Guides for getting things done, programming well, and programming in style.
 
+* [Enterprise Merge](/enterprise_merge)
 * [OS Packaging](/packaging)
 * [Travis CI](/travis)
 * [Uncrustify Formatter](/uncrustify)

--- a/enterprise_merge/Makefile
+++ b/enterprise_merge/Makefile
@@ -1,0 +1,14 @@
+# needed variables will be passed in via top-level Makefile
+
+INSTALL := install -c
+INSTALL_SCRIPT := $(INSTALL) -m 755
+ENTERPRISE_MERGE_SCRIPTS := $(filter-out README.md Makefile,$(wildcard *))
+
+all:
+
+clean:
+
+install: all
+	$(INSTALL_SCRIPT) $(ENTERPRISE_MERGE_SCRIPTS) $(DESTDIR)$(bindir)
+
+.PHONY: clean installdirs install

--- a/enterprise_merge/README.md
+++ b/enterprise_merge/README.md
@@ -1,0 +1,29 @@
+# Enterprise Merge Automation
+
+Tools for automating git merges from Citus community to enterprise. The documentation for the process is at https://github.com/citusdata/citus-enterprise/blob/enterprise-master/ci/README.md#check_enterprise_mergesh
+
+The script is designed to be able to resume where it left off, in the case that it failed on some of the steps.
+
+It is also possible to force the script to start from a particular step by providing an optional parameter.
+
+# Dependencies
+
+The script depends on [GitHub Cli](https://github.com/cli/cli) to be able to open PRs after the merges are complete.
+
+# Usage
+
+The script expects to be run inside the Citus Enterprise repo directory.
+
+```sh
+enterprise_merge $PR_BRANCH
+# e.g.
+enterprise_merge my_feature_branch_name_on_citus_community
+```
+
+You can also supply an optional step number to force the script to start from that particular step.
+
+```sh
+enterprise_merge $PR_BRANCH $STEP_NUMBER
+# e.g. to force the tool to start from pushing the branch to remote
+enterprise_merge my_feature_branch_name_on_citus_community 7
+```

--- a/enterprise_merge/enterprise_merge
+++ b/enterprise_merge/enterprise_merge
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -eu
+
+# heavily inspired by the design in https://www.unix.com/302919322-post15.html
+
+function die {
+	echo "$1"
+	exit 1
+}
+
+function usage {
+	cat <<-HELP_USAGE
+
+		$0  branch_name [force_enterprise_merge_step]
+
+		branch_name                   branch name on community repo
+		force_enterprise_merge_step   optional step number for enterprise merges
+
+	HELP_USAGE
+}
+
+case "$#" in
+1)
+	PR_BRANCH=$1
+
+	if [ -f last_enterprise_merge_step ]; then
+		read -r CURRENT_STEP <last_enterprise_merge_step
+	else
+		CURRENT_STEP=1
+	fi
+	;;
+2)
+	PR_BRANCH=$1
+	CURRENT_STEP="$2"
+	;;
+*)
+	usage
+	exit 1
+	;;
+esac
+
+# finish ongoing git merges if there are any
+if [ -f .git/MERGE_HEAD ]; then
+	git merge --continue
+fi
+
+# go through the actual steps for enterprise merges
+FINISHED=0
+while [ "$FINISHED" -eq 0 ]; do
+	case "$CURRENT_STEP" in
+	1)
+		git checkout enterprise-master
+		;;
+	2)
+		git pull
+		;;
+	3)
+		git fetch community
+		;;
+	4)
+		git checkout -B "$PR_BRANCH" enterprise-master
+		;;
+	5)
+		git merge community/master ||
+			die "Failed to merge community/master. Please resolve conflicts and re-run the script"
+		;;
+	6)
+		git merge "community/$PR_BRANCH" ||
+			die "Failed to merge community/$PR_BRANCH. Please resolve conflicts and re-run the script"
+		;;
+	7)
+		git push origin "$PR_BRANCH"
+		;;
+	8)
+		gh pr create --head "$PR_BRANCH" \
+			--title "Merge to enterprise for branch $PR_BRANCH" \
+			--body "Enterprise merge for PR"
+		;;
+	*)
+		FINISHED=1
+		;;
+	esac
+
+	CURRENT_STEP=$((CURRENT_STEP + 1))
+	echo $CURRENT_STEP >last_enterprise_merge_step
+done
+
+echo "Completed all steps for enterprise merge, removing flag file"
+rm -f last_enterprise_merge_step

--- a/enterprise_merge/enterprise_merge
+++ b/enterprise_merge/enterprise_merge
@@ -75,7 +75,7 @@ while [ "$FINISHED" -eq 0 ]; do
 	8)
 		gh pr create --head "$PR_BRANCH" \
 			--title "Merge to enterprise for branch $PR_BRANCH" \
-			--body "Enterprise merge for PR"
+			--body "This PR is created automagically via https://github.com/citusdata/tools/tree/develop/enterprise_merge"
 		;;
 	*)
 		FINISHED=1


### PR DESCRIPTION
# Enterprise Merge Automation

Tools for automating git merges from Citus community to enterprise. The documentation for the process is at https://github.com/citusdata/citus-enterprise/blob/enterprise-master/ci/README.md#check_enterprise_mergesh

The script is designed to be able to resume where it left off, in the case that it failed on some of the steps.

It is also possible to force the script to start from a particular step by providing an optional parameter.

# Dependencies

The script depends on [GitHub Cli](https://github.com/cli/cli) to be able to open PRs after the merges are complete.

# Usage

The script expects to be run inside the Citus Enterprise repo directory.

```sh
enterprise_merge $PR_BRANCH
# e.g.
enterprise_merge my_feature_branch_name_on_citus_community
```

You can also supply an optional step number to force the script to start from that particular step.

```sh
enterprise_merge $PR_BRANCH $STEP_NUMBER
# e.g. to force the tool to start from pushing the branch to remote
enterprise_merge my_feature_branch_name_on_citus_community 7
```