### PR TITLE
Fixes tag check on branch code

### DIFF
--- a/packaging_automation/common_tool_methods.py
+++ b/packaging_automation/common_tool_methods.py
@@ -322,11 +322,11 @@ def is_tag_on_branch(tag_name: str, branch_name: str):
     g = git.Git(os.getcwd())
     try:
         branches_str = g.execute(["git", "branch", "--contains", f"tags/{tag_name}"])
-        branches = remove_prefix(branches_str, "*").split("\n")
+        branches = branches_str.split("\n")
         print("Branches str:" + branches_str)
         if len(branches) > 0:
             for branch in branches:
-                if branch.strip() == branch_name:
+                if remove_prefix(branch, "*").strip() == branch_name:
                     return True
         return False
     except GitCommandError as e:

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -44,6 +44,7 @@ GITHUB_TOKEN = os.getenv("GH_TOKEN")
 BASE_PATH = pathlib2.Path(__file__).parents[1]
 TEST_BASE_PATH = pathlib2.Path(__file__).parent.absolute()
 TEST_GPG_KEY_NAME = "Citus Data <packaging@citusdata.com>"
+UNIT_TEST_BRANCH = "unit_test_branch"
 
 
 def test_find_nth_occurrence_position():
@@ -84,7 +85,10 @@ def test_get_version_details():
 
 def test_is_tag_on_branch():
     current_branch = get_current_branch(os.getcwd())
-    assert is_tag_on_branch("v0.8.3", current_branch)
+    run(f"git checkout develop")
+    assert is_tag_on_branch("v0.8.3", "develop")
+    assert not is_tag_on_branch("v1.8.3", "develop")
+    run(f"git checkout {current_branch}")
 
 
 def test_replace_line_in_file():

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -44,7 +44,6 @@ GITHUB_TOKEN = os.getenv("GH_TOKEN")
 BASE_PATH = pathlib2.Path(__file__).parents[1]
 TEST_BASE_PATH = pathlib2.Path(__file__).parent.absolute()
 TEST_GPG_KEY_NAME = "Citus Data <packaging@citusdata.com>"
-UNIT_TEST_BRANCH = "unit_test_branch"
 
 
 def test_find_nth_occurrence_position():
@@ -85,7 +84,7 @@ def test_get_version_details():
 
 def test_is_tag_on_branch():
     current_branch = get_current_branch(os.getcwd())
-    run(f"git checkout develop")
+    run("git checkout develop")
     assert is_tag_on_branch("v0.8.3", "develop")
     assert not is_tag_on_branch("v1.8.3", "develop")
     run(f"git checkout {current_branch}")

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -44,6 +44,7 @@ GITHUB_TOKEN = os.getenv("GH_TOKEN")
 BASE_PATH = pathlib2.Path(__file__).parents[1]
 TEST_BASE_PATH = pathlib2.Path(__file__).parent.absolute()
 TEST_GPG_KEY_NAME = "Citus Data <packaging@citusdata.com>"
+UNIT_TEST_BRANCH = "unit_test_branch"
 
 
 def test_find_nth_occurrence_position():
@@ -85,8 +86,8 @@ def test_get_version_details():
 def test_is_tag_on_branch():
     current_branch = get_current_branch(os.getcwd())
     run("git checkout develop")
-    assert is_tag_on_branch("v0.8.3", "develop")
-    assert not is_tag_on_branch("v1.8.3", "develop")
+    assert is_tag_on_branch("v0.8.3", UNIT_TEST_BRANCH)
+    assert not is_tag_on_branch("v1.8.3", UNIT_TEST_BRANCH)
     run(f"git checkout {current_branch}")
 
 

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -44,7 +44,6 @@ GITHUB_TOKEN = os.getenv("GH_TOKEN")
 BASE_PATH = pathlib2.Path(__file__).parents[1]
 TEST_BASE_PATH = pathlib2.Path(__file__).parent.absolute()
 TEST_GPG_KEY_NAME = "Citus Data <packaging@citusdata.com>"
-UNIT_TEST_BRANCH = "unit_test_branch"
 
 
 def test_find_nth_occurrence_position():

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -85,10 +85,7 @@ def test_get_version_details():
 
 def test_is_tag_on_branch():
     current_branch = get_current_branch(os.getcwd())
-    run(f"git checkout {UNIT_TEST_BRANCH}")
-    assert is_tag_on_branch("v0.8.3", UNIT_TEST_BRANCH)
-    assert not is_tag_on_branch("v1.8.3", UNIT_TEST_BRANCH)
-    run(f"git checkout {current_branch}")
+    assert is_tag_on_branch("v0.8.3", current_branch)
 
 
 def test_replace_line_in_file():

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -85,7 +85,7 @@ def test_get_version_details():
 
 def test_is_tag_on_branch():
     current_branch = get_current_branch(os.getcwd())
-    run("git checkout develop")
+    run(f"git checkout ${UNIT_TEST_BRANCH}")
     assert is_tag_on_branch("v0.8.3", UNIT_TEST_BRANCH)
     assert not is_tag_on_branch("v1.8.3", UNIT_TEST_BRANCH)
     run(f"git checkout {current_branch}")

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -85,7 +85,7 @@ def test_get_version_details():
 
 def test_is_tag_on_branch():
     current_branch = get_current_branch(os.getcwd())
-    run(f"git checkout ${UNIT_TEST_BRANCH}")
+    run(f"git checkout {UNIT_TEST_BRANCH}")
     assert is_tag_on_branch("v0.8.3", UNIT_TEST_BRANCH)
     assert not is_tag_on_branch("v1.8.3", UNIT_TEST_BRANCH)
     run(f"git checkout {current_branch}")


### PR DESCRIPTION
Unit tests was failing for tag check operation. There was a bug on stripping '*' from branch name. Fixed the issue. Previously, I changed the logic but after the comments and detailed investiogation I found out that there is no need for a logic change so I rolledback and applied the solution that keeps the same approach but fixed the bug.

Problem here is current branch starts with * character and previously I strip the fist character of the unsplitted text. However, order of the current branch may change and may be somewhere in between unsplitted text so I splitted the text and removed * character for each branch