### PR TITLE
Adds schedule for package delete on PackageCloud

### DIFF
--- a/.github/workflows/delete-packagecloud-packages.yml
+++ b/.github/workflows/delete-packagecloud-packages.yml
@@ -8,10 +8,11 @@ on:
     branches:
       - "**"
     schedule:
+      # https://crontab.guru/#0_18_*_*_*
       - cron: "0 18 * * *"
 
 jobs:
-  unit_test_execution:
+  delete_packagecloud_packages:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -30,7 +31,7 @@ jobs:
       - name: Install python requirements
         run: python -m pip install -r packaging_automation/requirements.txt
 
-      - name: Delete PackageCloud packages
+      - name: Delete Old Nightly PackageCloud Packages
         run: |
           python -m packaging_automation.delete_packages_on_packagecloud \
           --package_repo ${{ matrix.package_repository }} \

--- a/.github/workflows/delete-packagecloud-packages.yml
+++ b/.github/workflows/delete-packagecloud-packages.yml
@@ -1,0 +1,37 @@
+name: PackageCloud nightly package delete schedule
+
+env:
+  PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
+
+on:
+  push:
+    branches:
+      - "**"
+    schedule:
+      - cron: "0 18 * * *"
+
+jobs:
+  unit_test_execution:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package_repository:
+          - community-nightlies
+          - enterprise-nightlies
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
+
+      - name: Install python requirements
+        run: python -m pip install -r packaging_automation/requirements.txt
+
+      - name: Delete PackageCloud packages
+        run: |
+          python -m packaging_automation.delete_packages_on_packagecloud \
+          --package_repo ${{ matrix.package_repository }} \
+          --package_cloud_api_token ${PACKAGE_CLOUD_API_TOKEN}

--- a/.github/workflows/delete-packagecloud-packages.yml
+++ b/.github/workflows/delete-packagecloud-packages.yml
@@ -7,9 +7,9 @@ on:
   push:
     branches:
       - "**"
-    schedule:
-      # https://crontab.guru/#0_18_*_*_*
-      - cron: "0 18 * * *"
+  schedule:
+    # https://crontab.guru/#0_18_*_*_*
+    - cron: "0 18 * * *"
 
 jobs:
   delete_packagecloud_packages:

--- a/.github/workflows/delete-packagecloud-packages.yml
+++ b/.github/workflows/delete-packagecloud-packages.yml
@@ -4,9 +4,6 @@ env:
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
 
 on:
-  push:
-    branches:
-      - "**"
   schedule:
     # https://crontab.guru/#0_18_*_*_*
     - cron: "0 18 * * *"

--- a/packaging_automation/delete_packages_on_packagecloud.py
+++ b/packaging_automation/delete_packages_on_packagecloud.py
@@ -1,0 +1,57 @@
+import requests
+import json
+from datetime import datetime
+import argparse
+from enum import Enum
+
+PAGE_RECORD_COUNT = 100
+
+
+class PackageRepository(Enum):
+    community_nightlies = "community-nightlies"
+    enterprise_nightlies = "enterprise-nightlies"
+
+
+def delete_packages(repo: PackageRepository, package_cloud_api_token: str) -> None:
+    url_prefix = f"https://{package_cloud_api_token}:@packagecloud.io"
+
+    successful_count = 0
+    error_count = 0
+    end_of_limits_reached = False
+    while True:
+        list_url = (f"{url_prefix}/api/v1/repos/citusdata/{repo.value}"
+                    f"/packages.json?per_page={PAGE_RECORD_COUNT}&page=0")
+        result = requests.get(list_url)
+        package_info_list = json.loads(result.content)
+        if len(package_info_list) == 0 or end_of_limits_reached:
+            break
+        for package_info in package_info_list:
+            package_upload_date = datetime.strptime(package_info['created_at'], "%Y-%m-%dT%H:%M:%S.000Z")
+            diff = datetime.now() - package_upload_date
+            if diff.days > 10:
+                delete_url = f"{url_prefix}{package_info['destroy_url']}"
+
+                del_result = requests.delete(delete_url)
+                if del_result.status_code == 200:
+                    print(f"{package_info['filename']} deleted successfully")
+                    successful_count = successful_count + 1
+                else:
+                    error_count = error_count + 1
+                    print(
+                        f"{package_info['filename']} could not be deleted. Error Code:{del_result.status_code} "
+                        f"Error message:{del_result.content}")
+            else:
+                end_of_limits_reached = True
+
+    print("Deletion Stats")
+    print(f"Succesful Count: {successful_count}")
+    print(f"Error Count:{error_count}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--package_repo', choices=[r.value for r in PackageRepository], required=True)
+    parser.add_argument('--package_cloud_api_token', required=True)
+    args = parser.parse_args()
+
+    delete_packages(repo=PackageRepository(args.package_repo), package_cloud_api_token=args.package_cloud_api_token)

--- a/packaging_automation/tests/test_update_docker.py
+++ b/packaging_automation/tests/test_update_docker.py
@@ -24,7 +24,6 @@ PKGVARS_FILE = f"{TEST_BASE_PATH}/pkgvars"
 
 def setup_module():
     if not os.path.exists("docker"):
-        # TODO Remove branch name after merge of docker/PR# 281
         run("git clone https://github.com/citusdata/docker.git")
 
 

--- a/packaging_automation/tests/test_update_docker.py
+++ b/packaging_automation/tests/test_update_docker.py
@@ -25,7 +25,7 @@ PKGVARS_FILE = f"{TEST_BASE_PATH}/pkgvars"
 def setup_module():
     if not os.path.exists("docker"):
         # TODO Remove branch name after merge of docker/PR# 281
-        run("git clone --branch add_pkgvars https://github.com/citusdata/docker.git")
+        run("git clone https://github.com/citusdata/docker.git")
 
 
 def teardown_module():


### PR DESCRIPTION
Recently, we exceeded our PackageCloud subscription plan storage limits so we decided to delete unnecessary nightly packages from our nightly repositories. I manually deleted the packages for once. With this schedule package deletion is being scheduled so unnecessary package deletion (packages older than 10 days) would be scheduled and we would remove the risk to exceed our storage limits.
Additinally I needed to remove the branch name in the unit test for update_docker since branch is deleted and unnecessary now
By the way you can not see any deleted packages, in the latest execution because packages already deleted in the older executions
You can see successful deletion for community on the execution below
https://github.com/citusdata/tools/runs/4949704514?check_suite_focus=true
For enterprise I deleted the applicable packages while testing so you can see package deletions tomorrow at 15:00 pm Istanbul Time
