### PR TITLE
Adds beta support for releases

### DIFF
--- a/.github/workflows/citus-package-all-platforms-beta-test.yml
+++ b/.github/workflows/citus-package-all-platforms-beta-test.yml
@@ -50,4 +50,4 @@ jobs:
         run: python -m pip install -r packaging_automation/requirements.txt
 
       - name: Citus package tests
-        run: python -m pytest -q packaging_automation/tests/test_citus_package.py
+        run: python -m pytest -q packaging_automation/tests/test_citus_package.py -s

--- a/.github/workflows/citus-package-all-platforms-beta-test.yml
+++ b/.github/workflows/citus-package-all-platforms-beta-test.yml
@@ -1,0 +1,53 @@
+name: Citus package all platforms beta tests
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
+  MICROSOFT_EMAIL: gindibay@microsoft.com
+  USER_NAME: Gurkan Indibay
+  MAIN_BRANCH: all-citus
+  PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
+  PACKAGING_BRANCH_NAME: all-citus-unit-tests-beta
+
+on:
+  push:
+    branches:
+      - "**"
+
+  workflow_dispatch:
+
+jobs:
+  unit_test_execution:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - el/7
+          - el/8
+          - ol/7
+          - ol/8
+          - debian/stretch
+          - debian/buster
+          - debian/bullseye
+          - ubuntu/bionic
+          - ubuntu/focal
+    env:
+      PLATFORM: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources
+
+      - name: Define git credentails
+        run: git config --global user.email "${MICROSOFT_EMAIL}"&& git config --global user.name "${USER_NAME}"
+
+      - name: Install python requirements
+        run: python -m pip install -r packaging_automation/requirements.txt
+
+      - name: Citus package tests
+        run: python -m pytest -q packaging_automation/tests/test_citus_package.py

--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -49,4 +49,4 @@ jobs:
         run: python -m pip install -r packaging_automation/requirements.txt
 
       - name: Citus package tests
-        run: python -m pytest -q packaging_automation/tests/test_citus_package.py
+        run: python -m pytest -q packaging_automation/tests/test_citus_package.py -s

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -269,9 +269,10 @@ def build_packages(github_token: non_empty(non_blank(str)),
     os_name, os_version = decode_os_and_release(platform)
     release_versions, nightly_versions = get_postgres_versions(os_name, input_output_parameters.input_files_dir)
     signing_credentials = get_signing_credentials(signing_credentials.secret_key, signing_credentials.passphrase)
-
-    package_version = get_package_version_without_release_stage_from_pkgvars(input_output_parameters.input_files_dir)
-    write_postgres_versions_into_file(input_output_parameters.input_files_dir, package_version)
+    if platform != "pgxn":
+        package_version = get_package_version_without_release_stage_from_pkgvars(
+            input_output_parameters.input_files_dir)
+        write_postgres_versions_into_file(input_output_parameters.input_files_dir, package_version)
 
     if not signing_credentials.passphrase:
         raise ValueError("PACKAGING_PASSPHRASE should not be null or empty")

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -214,7 +214,7 @@ def get_postgres_versions(os_name: str, input_files_dir: str) -> Tuple[List[str]
         release_versions = ["all"]
         nightly_versions = ["all"]
     else:
-        package_version = get_package_version_from_pkgvars(input_files_dir)
+        package_version = get_package_version_without_release_stage_from_pkgvars(input_files_dir)
         release_versions = get_supported_postgres_release_versions(f"{input_files_dir}/{POSTGRES_MATRIX_FILE_NAME}",
                                                                    package_version)
         nightly_versions = get_supported_postgres_nightly_versions(f"{input_files_dir}/{POSTGRES_MATRIX_FILE_NAME}")
@@ -270,7 +270,7 @@ def build_packages(github_token: non_empty(non_blank(str)),
     release_versions, nightly_versions = get_postgres_versions(os_name, input_output_parameters.input_files_dir)
     signing_credentials = get_signing_credentials(signing_credentials.secret_key, signing_credentials.passphrase)
 
-    package_version = get_package_version_from_pkgvars(input_output_parameters.input_files_dir)
+    package_version = get_package_version_without_release_stage_from_pkgvars(input_output_parameters.input_files_dir)
     write_postgres_versions_into_file(input_output_parameters.input_files_dir, package_version)
 
     if not signing_credentials.passphrase:
@@ -304,6 +304,7 @@ def get_package_version_from_pkgvars(input_files_dir: str):
 
     if len(version_parts) < 3:
         raise ValueError("Version should at least contains three parts seperated with '.'. e.g 10.0.2-1")
+
     third_part_splitted = version_parts[2].split("-")
 
     if pkg_name == 'hll':
@@ -311,6 +312,15 @@ def get_package_version_from_pkgvars(input_files_dir: str):
     else:
         package_version = f"{version_parts[0]}.{version_parts[1]}.{third_part_splitted[0]}"
     return package_version
+
+
+def get_package_version_without_release_stage_from_pkgvars(input_files_dir: str):
+    version = get_package_version_from_pkgvars(input_files_dir)
+    return tear_release_stage_from_package_version(version)
+
+
+def tear_release_stage_from_package_version(package_version: str) -> str:
+    return package_version.split("_")[0]
 
 
 if __name__ == "__main__":

--- a/packaging_automation/templates/citus.spec.tmpl
+++ b/packaging_automation/templates/citus.spec.tmpl
@@ -43,6 +43,7 @@ make %{?_smp_mflags}
 # Install documentation with a better name:
 %{__mkdir} -p %{buildroot}%{pginstdir}/doc/extension
 %{__cp} README.md %{buildroot}%{pginstdir}/doc/extension/README-%{sname}.md
+%{__cp} NOTICE %{buildroot}%{pginstdir}/doc/extension/NOTICE-%{sname}
 # Set paths to be packaged other than LICENSE, README & CHANGELOG.md
 echo %{pginstdir}/include/server/citus_*.h >> installation_files.list
 echo %{pginstdir}/include/server/distributed/*.h >> installation_files.list
@@ -77,6 +78,7 @@ echo %{pginstdir}/share/extension/%{sname}.control >> installation_files.list
 %license LICENSE
 %endif
 %doc %{pginstdir}/doc/extension/README-%{sname}.md
+%doc %{pginstdir}/doc/extension/NOTICE-%{sname}
 
 %changelog
 {{changelog}}

--- a/packaging_automation/tests/files/citus.spec
+++ b/packaging_automation/tests/files/citus.spec
@@ -43,6 +43,7 @@ make %{?_smp_mflags}
 # Install documentation with a better name:
 %{__mkdir} -p %{buildroot}%{pginstdir}/doc/extension
 %{__cp} README.md %{buildroot}%{pginstdir}/doc/extension/README-%{sname}.md
+%{__cp} NOTICE %{buildroot}%{pginstdir}/doc/extension/NOTICE-%{sname}
 # Set paths to be packaged other than LICENSE, README & CHANGELOG.md
 echo %{pginstdir}/include/server/citus_*.h >> installation_files.list
 echo %{pginstdir}/include/server/distributed/*.h >> installation_files.list
@@ -77,6 +78,7 @@ echo %{pginstdir}/share/extension/%{sname}.control >> installation_files.list
 %license LICENSE
 %endif
 %doc %{pginstdir}/doc/extension/README-%{sname}.md
+%doc %{pginstdir}/doc/extension/NOTICE-%{sname}
 
 %changelog
 * Thu Mar 4 2021 - Gurkan Indibay <gindibay@microsoft.com> 10.0.2.citus-1

--- a/packaging_automation/tests/files/citus_include_10_0_3.spec
+++ b/packaging_automation/tests/files/citus_include_10_0_3.spec
@@ -43,6 +43,7 @@ make %{?_smp_mflags}
 # Install documentation with a better name:
 %{__mkdir} -p %{buildroot}%{pginstdir}/doc/extension
 %{__cp} README.md %{buildroot}%{pginstdir}/doc/extension/README-%{sname}.md
+%{__cp} NOTICE %{buildroot}%{pginstdir}/doc/extension/NOTICE-%{sname}
 # Set paths to be packaged other than LICENSE, README & CHANGELOG.md
 echo %{pginstdir}/include/server/citus_*.h >> installation_files.list
 echo %{pginstdir}/include/server/distributed/*.h >> installation_files.list
@@ -77,6 +78,7 @@ echo %{pginstdir}/share/extension/%{sname}.control >> installation_files.list
 %license LICENSE
 %endif
 %doc %{pginstdir}/doc/extension/README-%{sname}.md
+%doc %{pginstdir}/doc/extension/NOTICE-%{sname}
 
 %changelog
 * Thu Mar 18 2021 - Gurkan Indibay <gindibay@microsoft.com> 10.0.3.citus-1

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -7,7 +7,7 @@ from ..citus_package import (POSTGRES_MATRIX_FILE_NAME, POSTGRES_VERSION_FILE,
                              BuildType, InputOutputParameters,
                              SigningCredentials, build_packages,
                              decode_os_and_release, get_build_platform,
-                             get_package_version_from_pkgvars,
+                             get_package_version_without_release_stage_from_pkgvars,
                              get_release_package_folder_name)
 
 from ..common_tool_methods import (define_rpm_public_key_to_machine, delete_all_gpg_keys_by_name,
@@ -47,7 +47,7 @@ PLATFORM = get_build_platform(os.getenv("PLATFORM"), os.getenv("PACKAGING_IMAGE_
 
 
 def get_required_package_count(input_files_dir: str, platform: str):
-    package_version = get_package_version_from_pkgvars(input_files_dir)
+    package_version = get_package_version_without_release_stage_from_pkgvars(input_files_dir)
     release_versions = get_supported_postgres_release_versions(f"{input_files_dir}/{POSTGRES_MATRIX_FILE_NAME}",
                                                                package_version)
     return len(release_versions) * single_postgres_package_counts[platform]
@@ -92,7 +92,7 @@ def test_build_packages():
     postgres_version_file_path = f"{PACKAGING_EXEC_FOLDER}/{POSTGRES_VERSION_FILE}"
     assert os.path.exists(postgres_version_file_path)
     config = dotenv_values(postgres_version_file_path)
-    assert config["release_versions"] == "11,12,13"
+    assert config["release_versions"] == "12,13,14"
     assert config["nightly_versions"] == "12,13,14"
 
 

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -44,6 +44,7 @@ GH_TOKEN = os.getenv("GH_TOKEN")
 PACKAGE_CLOUD_API_TOKEN = os.getenv("PACKAGE_CLOUD_API_TOKEN")
 REPO_CLIENT_SECRET = os.getenv("REPO_CLIENT_SECRET")
 PLATFORM = get_build_platform(os.getenv("PLATFORM"), os.getenv("PACKAGING_IMAGE_PLATFORM"))
+PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-unit-tests")
 
 
 def get_required_package_count(input_files_dir: str, platform: str):
@@ -59,7 +60,7 @@ def setup_module():
     packaging_branch_name = "pgxn-citus" if PLATFORM == "pgxn" else "all-citus-unit-tests"
     if not os.path.exists(PACKAGING_EXEC_FOLDER):
         run(
-            f"git clone --branch {packaging_branch_name} https://github.com/citusdata/packaging.git"
+            f"git clone --branch {PACKAGING_BRANCH_NAME} https://github.com/citusdata/packaging.git"
             f" {PACKAGING_EXEC_FOLDER}")
 
 

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -57,10 +57,10 @@ def get_required_package_count(input_files_dir: str, platform: str):
 def setup_module():
     # Run tests against "all-citus-unit-tests" since we don't want to deal with the changes
     # made to "all-citus" in each release.
-    packaging_branch_name = "pgxn-citus" if PLATFORM == "pgxn" else "all-citus-unit-tests"
+    packaging_branch_name = "pgxn-citus" if PLATFORM == "pgxn" else PACKAGING_BRANCH_NAME
     if not os.path.exists(PACKAGING_EXEC_FOLDER):
         run(
-            f"git clone --branch {PACKAGING_BRANCH_NAME} https://github.com/citusdata/packaging.git"
+            f"git clone --branch {packaging_branch_name} https://github.com/citusdata/packaging.git"
             f" {PACKAGING_EXEC_FOLDER}")
 
 

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -88,8 +88,11 @@ def test_build_packages():
     sub_folder = get_release_package_folder_name(os_name, os_version)
     release_output_folder = f"{BASE_OUTPUT_FOLDER}/{sub_folder}"
     delete_all_gpg_keys_by_name(TEST_GPG_KEY_NAME)
-    assert len(os.listdir(release_output_folder)) == get_required_package_count(input_files_dir=PACKAGING_EXEC_FOLDER,
-                                                                                platform=PLATFORM)
+
+    if PLATFORM != "pgxn":
+        assert len(os.listdir(release_output_folder)) == get_required_package_count(
+            input_files_dir=PACKAGING_EXEC_FOLDER,
+            platform=PLATFORM)
     postgres_version_file_path = f"{PACKAGING_EXEC_FOLDER}/{POSTGRES_VERSION_FILE}"
     assert os.path.exists(postgres_version_file_path)
     config = dotenv_values(postgres_version_file_path)

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -89,15 +89,15 @@ def test_build_packages():
     release_output_folder = f"{BASE_OUTPUT_FOLDER}/{sub_folder}"
     delete_all_gpg_keys_by_name(TEST_GPG_KEY_NAME)
 
+    postgres_version_file_path = f"{PACKAGING_EXEC_FOLDER}/{POSTGRES_VERSION_FILE}"
     if PLATFORM != "pgxn":
         assert len(os.listdir(release_output_folder)) == get_required_package_count(
             input_files_dir=PACKAGING_EXEC_FOLDER,
             platform=PLATFORM)
-    postgres_version_file_path = f"{PACKAGING_EXEC_FOLDER}/{POSTGRES_VERSION_FILE}"
-    assert os.path.exists(postgres_version_file_path)
-    config = dotenv_values(postgres_version_file_path)
-    assert config["release_versions"] == "12,13,14"
-    assert config["nightly_versions"] == "12,13,14"
+        assert os.path.exists(postgres_version_file_path)
+        config = dotenv_values(postgres_version_file_path)
+        assert config["release_versions"] == "12,13,14"
+        assert config["nightly_versions"] == "12,13,14"
 
 
 def test_get_required_package_count():

--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -6,7 +6,8 @@ import pytest
 
 from .test_utils import generate_new_gpg_key
 from ..citus_package import (decode_os_and_release, is_docker_running, get_signing_credentials, get_postgres_versions,
-                             build_package, BuildType, sign_packages, SigningCredentials, InputOutputParameters)
+                             build_package, BuildType, sign_packages, SigningCredentials, InputOutputParameters,
+                             get_package_version_without_release_stage_from_pkgvars, write_postgres_versions_into_file)
 from ..common_tool_methods import (delete_all_gpg_keys_by_name, get_gpg_fingerprints_by_name, run,
                                    get_private_key_by_fingerprint_without_passphrase, define_rpm_public_key_to_machine,
                                    delete_rpm_key_by_name, get_private_key_by_fingerprint_with_passphrase,
@@ -101,6 +102,9 @@ def test_get_postgres_versions():
 def test_build_package_debian():
     input_output_parameters = InputOutputParameters.build(PACKAGING_EXEC_FOLDER, f"{OUTPUT_FOLDER}/debian-stretch",
                                                           output_validation=False)
+
+    package_version = get_package_version_without_release_stage_from_pkgvars(input_output_parameters.input_files_dir)
+    write_postgres_versions_into_file(input_output_parameters.input_files_dir, package_version)
 
     build_package(github_token=GH_TOKEN, build_type=BuildType.release,
                   docker_platform="debian-stretch", postgres_version="all",

--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -104,7 +104,7 @@ def test_build_package_debian():
 
     build_package(github_token=GH_TOKEN, build_type=BuildType.release,
                   docker_platform="debian-stretch", postgres_version="all",
-                  input_output_parameters=input_output_parameters)
+                  input_output_parameters=input_output_parameters, is_test=True)
 
 
 def test_build_package_rpm():
@@ -112,7 +112,8 @@ def test_build_package_rpm():
                                                           output_validation=False)
 
     build_package(github_token=GH_TOKEN, build_type=BuildType.release,
-                  docker_platform="centos-8", postgres_version="13", input_output_parameters=input_output_parameters)
+                  docker_platform="centos-8", postgres_version="13", input_output_parameters=input_output_parameters,
+                  is_test=True)
 
 
 def test_sign_packages():

--- a/packaging_automation/update_package_properties.py
+++ b/packaging_automation/update_package_properties.py
@@ -73,7 +73,7 @@ class PackagePropertiesParams:
     changelog_entry: str = ""
 
     @property
-    def changelog_version_entry(self)->str:
+    def changelog_version_entry(self) -> str:
         return f"{self.project_version}-{self.fancy_version_number}"
 
     @property
@@ -101,6 +101,17 @@ class PackagePropertiesParams:
     @property
     def rpm_version(self) -> str:
         return f"{self.project_version}{self.project_name_suffix}"
+
+    # debian changelog does not allow '_' character to be used in changelog. Therefore, we replace '_' with '-'
+    # to be able to release package without error
+    @property
+    def debian_changelog_project_version(self):
+        return f"{self.project_version.replace('_', '-')}"
+
+    @property
+    def debian_changelog_version_header(self):
+        fancy_suffix = f"{self.fancy_version_number}" if self.fancy else "1"
+        return f"{self.debian_changelog_project_version}{self.project_name_suffix}-{fancy_suffix}"
 
     @property
     def project_name_suffix(self) -> str:
@@ -161,7 +172,7 @@ def debian_changelog_header(supported_project: SupportedProject, project_version
                                                         project_version=project_version,
                                                         fancy=fancy, fancy_version_number=fancy_version_number)
 
-    version_on_changelog = package_properties_params.version_number_with_project_name
+    version_on_changelog = package_properties_params.debian_changelog_version_header
 
     return f"{supported_project.value.name} ({version_on_changelog}) stable; urgency=low"
 
@@ -222,7 +233,7 @@ def rpm_changelog_history(spec_file_path: str) -> str:
 
 
 def get_changelog_entry(package_properties_params: PackagePropertiesParams):
-    default_changelog_entry = f"Official {package_properties_params.project_version} release of " \
+    default_changelog_entry = f"Official {package_properties_params.debian_changelog_project_version} release of " \
                               f"{package_properties_params.changelog_project_name}"
     return (
         package_properties_params.changelog_entry if package_properties_params.changelog_entry

--- a/test-images/centos-8/Dockerfile
+++ b/test-images/centos-8/Dockerfile
@@ -14,7 +14,7 @@ ENV CITUS_VERSION ${CITUS_VERSION}
 ENV PG_MAJOR ${PG_MAJOR}
 
 RUN cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-*
 
 RUN yum update -y && \
     yum install -y curl

--- a/test-images/centos-8/Dockerfile
+++ b/test-images/centos-8/Dockerfile
@@ -13,6 +13,8 @@ ENV CITUS_VERSION ${CITUS_VERSION}
 
 ENV PG_MAJOR ${PG_MAJOR}
 
+RUN cd /etc/yum.repos.d/ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-* \
 
 RUN yum update -y && \
     yum install -y curl

--- a/test-images/debian-bullseye/Dockerfile
+++ b/test-images/debian-bullseye/Dockerfile
@@ -36,7 +36,6 @@ RUN apt-get update \
 RUN apt-get install -y postgresql-${PG_MAJOR}-citus-${CITUS_MAJOR_VERSION}=${CITUS_VERSION}.citus-${FANCY} \
                        postgresql-$PG_MAJOR-hll=${HLL_VERSION} \
                        postgresql-$PG_MAJOR-topn=${TOPN_VERSION} \
-    && apt-get purge -y --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*12
 
 

--- a/test-images/scripts/requirements.in
+++ b/test-images/scripts/requirements.in
@@ -3,7 +3,7 @@ GitPython
 Jinja2
 parameters_validation
 pathlib2
-pycurl
+pycurl<7.45.0
 PyGithub
 pytest
 python-gnupg


### PR DESCRIPTION
1. Adds a new unit test branch for beta packages all-citus-unit-tests-beta to be able to test beta packages
2. Updates Unit test templates since Unit test branches updated to 10.2.4.
3. Adds -s flag for pytest in test pipelines to be able to see the logs in successful executions
4. Strips release stage (beta) from version to be able to get postgres version properly
5. Fixed centos-8 mirror problem for packaging tests (Fixed since tests are failing)

TODO:  After merging this task I need to move v0.8.12 tag into develop branch