### PR TITLE
Fix & as reference formatting

### DIFF
--- a/uncrustify/citus-style.cfg
+++ b/uncrustify/citus-style.cfg
@@ -346,17 +346,17 @@ sp_ptr_star_paren                         = remove   # ignore/add/remove/force
 sp_before_ptr_star_func                   = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&'
-sp_before_byref                           = ignore   # ignore/add/remove/force
+sp_before_byref                           = remove   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&' that isn't followed by a variable name
 # If set to 'ignore', sp_before_byref is used instead.
 sp_before_unnamed_byref                   = ignore   # ignore/add/remove/force
 
 # Add or remove space after reference sign '&', if followed by a word.
-sp_after_byref                            = remove   # ignore/add/remove/force
+sp_after_byref                            = add   # ignore/add/remove/force
 
 # Add or remove space after a reference sign '&', if followed by a func proto/def.
-sp_after_byref_func                       = remove   # ignore/add/remove/force
+sp_after_byref_func                       = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&', if followed by a func proto/def.
 sp_before_byref_func                      = ignore   # ignore/add/remove/force


### PR DESCRIPTION
Currently, citus_indent formats
```cpp
try{
	// ...
} catch (const runtime_error& err)
```
to
```cpp
try{
	// ...
} catch (const runtime_error&err)
```

This change fixes that.