### PR TITLE
Adds exception support for postgres versions

### DIFF
--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -285,6 +285,7 @@ def get_docker_image_name(platform: str):
 @validate_parameters
 # disabled since this is related to parameter_validations library methods
 # pylint: disable=no-value-for-parameter
+# pylint: disable= too-many-locals
 def build_packages(github_token: non_empty(non_blank(str)),
                    platform: non_empty(non_blank(str)),
                    build_type: BuildType, signing_credentials: SigningCredentials,
@@ -308,7 +309,6 @@ def build_packages(github_token: non_empty(non_blank(str)),
                                                         os_name] == PostgresVersionDockerImageType.single \
         else postgress_versions_to_process
 
-    print(f"Postgres Versions: {str_array_to_str(postgres_docker_extension_iterator)}")
     docker_image_name = get_docker_image_name(platform)
     output_sub_folder = get_release_package_folder_name(os_name, os_version)
     input_output_parameters.output_dir = f"{input_output_parameters.output_dir}/{output_sub_folder}"

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -302,7 +302,7 @@ def build_packages(github_token: non_empty(non_blank(str)),
         raise ValueError("PACKAGING_PASSPHRASE should not be null or empty")
     postgress_versions_to_process = release_versions if build_type == BuildType.release else nightly_versions
 
-    postgres_docker_extension_iterator = "all" if platform_postgres_version_source[
+    postgres_docker_extension_iterator = ["all"] if platform_postgres_version_source[
                                                       os_name] == PostgresVersionDockerImageType.single \
         else postgress_versions_to_process
 

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -20,8 +20,7 @@ from .common_tool_methods import (DEFAULT_ENCODING_FOR_FILE_HANDLING,
                                   get_supported_postgres_nightly_versions,
                                   get_supported_postgres_release_versions,
                                   platform_names,
-                                  run_with_output, str_array_to_str,
-                                  supported_platforms,
+                                  run_with_output, supported_platforms,
                                   transform_key_into_base64_str)
 from .packaging_warning_handler import validate_output
 

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -162,14 +162,17 @@ def write_postgres_versions_into_file(input_files_dir: str, package_version: str
                                       platform: str = ""):
     # In ADO pipelines function without os_name and platform is used. If these parameters are unset
     if not os_name:
+        print("os name is empty")
         release_versions = get_supported_postgres_release_versions(f"{input_files_dir}/{POSTGRES_MATRIX_FILE_NAME}",
                                                                    package_version)
         nightly_versions = get_supported_postgres_nightly_versions(f"{input_files_dir}/{POSTGRES_MATRIX_FILE_NAME}")
     else:
+        print(f"os: {os_name} platform: {platform}")
         release_versions, nightly_versions = get_postgres_versions(os_name=os_name, platform=platform,
                                                                    input_files_dir=input_files_dir)
     release_version_str = ','.join(release_versions)
     nightly_version_str = ','.join(nightly_versions)
+    print(f"Release versions: {release_version_str}, Nightly versions: {nightly_version_str}")
     with open(f"{input_files_dir}/{POSTGRES_VERSION_FILE}", 'w', encoding=DEFAULT_ENCODING_FOR_FILE_HANDLING,
               errors=DEFAULT_UNICODE_ERROR_HANDLER) as f:
         f.write(f"release_versions={release_version_str}\n")

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -304,9 +304,10 @@ def build_packages(github_token: non_empty(non_blank(str)),
         raise ValueError("PACKAGING_PASSPHRASE should not be null or empty")
     postgress_versions_to_process = release_versions if build_type == BuildType.release else nightly_versions
 
-    postgres_docker_extension_iterator = ["all"] if platform_postgres_version_source[
-                                                        os_name] == PostgresVersionDockerImageType.single \
-        else postgress_versions_to_process
+    if platform_postgres_version_source[os_name] == PostgresVersionDockerImageType.single :
+        postgres_docker_extension_iterator = ["all"] 
+    else :
+        postgres_docker_extension_iterator = postgress_versions_to_process
 
     docker_image_name = get_docker_image_name(platform)
     output_sub_folder = get_release_package_folder_name(os_name, os_version)

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -375,7 +375,6 @@ if __name__ == "__main__":
     parser.add_argument('--passphrase', required=True)
     parser.add_argument('--output_dir', required=True)
     parser.add_argument('--input_files_dir', required=True)
-    parser.add_argument('--input_files_dir', required=True)
     parser.add_argument('--output_validation', action="store_true")
     parser.add_argument('--is_test', action="store_true")
 

--- a/packaging_automation/tests/files/get_postgres_versions_tests/pg_exclude.yml
+++ b/packaging_automation/tests/files/get_postgres_versions_tests/pg_exclude.yml
@@ -1,3 +1,5 @@
 exclude:
-  - ol/7:
-      postgres_versions: [15]
+  nightly:
+    ol/7: [15]
+  release:
+    all: [15]

--- a/packaging_automation/tests/files/get_postgres_versions_tests/pg_exclude.yml
+++ b/packaging_automation/tests/files/get_postgres_versions_tests/pg_exclude.yml
@@ -1,0 +1,3 @@
+exclude:
+  - ol/7:
+      postgres_versions: [15]

--- a/packaging_automation/tests/files/get_postgres_versions_tests/pkgvars
+++ b/packaging_automation/tests/files/get_postgres_versions_tests/pkgvars
@@ -1,0 +1,4 @@
+pkgname=citus
+pkgdesc='Citus (Open-Source)'
+pkglatest=11.0.5
+versioning=fancy

--- a/packaging_automation/tests/files/get_postgres_versions_tests/postgres-matrix.yml
+++ b/packaging_automation/tests/files/get_postgres_versions_tests/postgres-matrix.yml
@@ -1,0 +1,19 @@
+### THIS FILE IS ONLY FOR UNIT TESTS. ACTUAL POSTGRES MATRIX FILES ARE IN PACKAGING PROJECT BRANCHES ###
+name: Postgres Version Matrix
+project_name: citus # alternatives: citus, citus-enterprise, pg-auto-failover, pg-auto-failover-enterprise
+# There is one configuration like this for each project in packaging repo
+# i.e. in all-citus, all-enterprise, all-pgautofailover, all-pgautofailover-enterprise, pgxn-citus etc.
+version_matrix:
+  - 8.0:
+      postgres_versions: [10, 11]
+  - 9.0:
+      postgres_versions: [11, 12]
+  - 9.5:
+      postgres_versions: [11, 12, 13]
+  # If 10.0 is released, since it is between 10.1 and 9.5, 9.5 support will be effective for 10.0.x releases
+  - 10.1:
+      postgres_versions: [12, 13]
+  - 10.2:
+      postgres_versions: [12, 13, 14]
+  - 11:
+      postgres_versions: [13, 14, 15]

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -51,6 +51,7 @@ PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-pg15-beta"
 def get_required_package_count(input_files_dir: str, platform: str, os_name: str):
     release_versions, _ = get_postgres_versions(os_name=os_name, platform=platform,
                                                 input_files_dir=input_files_dir)
+    print (f"get_required_package_count: Relase versions:{release_versions}:{single_postgres_package_counts[platform]}")
     return len(release_versions) * single_postgres_package_counts[platform]
 
 

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -42,7 +42,7 @@ GH_TOKEN = os.getenv("GH_TOKEN")
 PACKAGE_CLOUD_API_TOKEN = os.getenv("PACKAGE_CLOUD_API_TOKEN")
 REPO_CLIENT_SECRET = os.getenv("REPO_CLIENT_SECRET")
 PLATFORM = get_build_platform(os.getenv("PLATFORM"), os.getenv("PACKAGING_IMAGE_PLATFORM"))
-PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-pg15-beta")
+PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-unit-tests")
 
 
 def get_required_package_count(input_files_dir: str, platform: str):

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -110,12 +110,20 @@ def test_decode_os_packages():
     assert os == "el" and release == "7"
 
 
-def test_get_postgres_versions():
+def test_get_postgres_versions_ol_7():
     release_versions, nightly_versions = get_postgres_versions(os_name="ol",
                                                                input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
                                                                platform="ol/7")
     assert len(release_versions) == 2 and release_versions == ['13', '14']
-    assert len(nightly_versions) == 2 and release_versions == ['13', '14']
+    assert len(nightly_versions) == 2 and nightly_versions == ['13', '14']
+
+
+def test_get_postgres_versions_el_7():
+    release_versions, nightly_versions = get_postgres_versions(os_name="el",
+                                                               input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
+                                                               platform="el/7")
+    assert len(release_versions) == 2 and release_versions == ['13', '14']
+    assert len(nightly_versions) == 3 and nightly_versions == ['13', '14', '15']
 
 def test_upload_to_package_cloud():
     platform = get_build_platform(os.getenv("PLATFORM"), os.getenv("PACKAGING_IMAGE_PLATFORM"))

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -48,10 +48,10 @@ PLATFORM = get_build_platform(os.getenv("PLATFORM"), os.getenv("PACKAGING_IMAGE_
 PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-unit-tests")
 
 
-def get_required_package_count(input_files_dir: str, platform: str, os_name: str):
-    release_versions, _ = get_postgres_versions(os_name=os_name, platform=platform,
+def get_required_package_count(input_files_dir: str, platform: str):
+    release_versions, _ = get_postgres_versions(platform=platform,
                                                 input_files_dir=input_files_dir)
-    print (f"get_required_package_count: Relase versions:{release_versions}:{single_postgres_package_counts[platform]}")
+    print(f"get_required_package_count: Relase versions:{release_versions}:{single_postgres_package_counts[platform]}")
     return len(release_versions) * single_postgres_package_counts[platform]
 
 
@@ -94,8 +94,7 @@ def test_build_packages():
     if PLATFORM != "pgxn":
         assert len(os.listdir(release_output_folder)) == get_required_package_count(
             input_files_dir=PACKAGING_EXEC_FOLDER,
-            platform=PLATFORM,
-            os_name=os_name)
+            platform=PLATFORM)
         assert os.path.exists(postgres_version_file_path)
         config = dotenv_values(postgres_version_file_path)
         assert config["release_versions"] == "12,13,14"
@@ -103,7 +102,7 @@ def test_build_packages():
 
 
 def test_get_required_package_count():
-    assert get_required_package_count(input_files_dir=PACKAGING_EXEC_FOLDER, platform="el/8", os_name="el") == 9
+    assert get_required_package_count(input_files_dir=PACKAGING_EXEC_FOLDER, platform="el/8") == 9
 
 
 def test_decode_os_packages():
@@ -112,19 +111,20 @@ def test_decode_os_packages():
 
 
 def test_get_postgres_versions_ol_7():
-    release_versions, nightly_versions = get_postgres_versions(os_name="ol",
-                                                               input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
-                                                               platform="ol/7")
+    release_versions, nightly_versions = get_postgres_versions(
+        input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
+        platform="ol/7")
     assert len(release_versions) == 2 and release_versions == ['13', '14']
     assert len(nightly_versions) == 2 and nightly_versions == ['13', '14']
 
 
 def test_get_postgres_versions_el_7():
-    release_versions, nightly_versions = get_postgres_versions(os_name="el",
-                                                               input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
-                                                               platform="el/7")
+    release_versions, nightly_versions = get_postgres_versions(
+        input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
+        platform="el/7")
     assert len(release_versions) == 2 and release_versions == ['13', '14']
     assert len(nightly_versions) == 3 and nightly_versions == ['13', '14', '15']
+
 
 def test_upload_to_package_cloud():
     platform = get_build_platform(os.getenv("PLATFORM"), os.getenv("PACKAGING_IMAGE_PLATFORM"))

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -45,7 +45,7 @@ GH_TOKEN = os.getenv("GH_TOKEN")
 PACKAGE_CLOUD_API_TOKEN = os.getenv("PACKAGE_CLOUD_API_TOKEN")
 REPO_CLIENT_SECRET = os.getenv("REPO_CLIENT_SECRET")
 PLATFORM = get_build_platform(os.getenv("PLATFORM"), os.getenv("PACKAGING_IMAGE_PLATFORM"))
-PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-pg15-beta")
+PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-unit-tests")
 
 
 def get_required_package_count(input_files_dir: str, platform: str, os_name: str):

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -1,24 +1,21 @@
 import os
 
 import pathlib2
+from dotenv import dotenv_values
 
 from .test_utils import generate_new_gpg_key
-from ..citus_package import (POSTGRES_MATRIX_FILE_NAME, POSTGRES_VERSION_FILE,
+from ..citus_package import (POSTGRES_VERSION_FILE,
                              BuildType, InputOutputParameters,
                              SigningCredentials, build_packages,
                              decode_os_and_release, get_build_platform,
-                             get_package_version_without_release_stage_from_pkgvars,
                              get_release_package_folder_name, get_postgres_versions)
-
 from ..common_tool_methods import (define_rpm_public_key_to_machine, delete_all_gpg_keys_by_name,
                                    delete_rpm_key_by_name, get_gpg_fingerprints_by_name,
                                    get_private_key_by_fingerprint_with_passphrase,
-                                   get_supported_postgres_release_versions, run,
+                                   run,
                                    transform_key_into_base64_str, verify_rpm_signature_in_dir)
 from ..upload_to_package_cloud import (delete_package_from_package_cloud, package_exists,
                                        upload_files_in_directory_to_package_cloud)
-
-from dotenv import dotenv_values
 
 TEST_BASE_PATH = os.getenv("BASE_PATH", default=pathlib2.Path(__file__).parents[2])
 
@@ -45,7 +42,7 @@ GH_TOKEN = os.getenv("GH_TOKEN")
 PACKAGE_CLOUD_API_TOKEN = os.getenv("PACKAGE_CLOUD_API_TOKEN")
 REPO_CLIENT_SECRET = os.getenv("REPO_CLIENT_SECRET")
 PLATFORM = get_build_platform(os.getenv("PLATFORM"), os.getenv("PACKAGING_IMAGE_PLATFORM"))
-PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-unit-tests")
+PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-pg15-beta")
 
 
 def get_required_package_count(input_files_dir: str, platform: str):
@@ -122,6 +119,14 @@ def test_get_postgres_versions_el_7():
     release_versions, nightly_versions = get_postgres_versions(
         input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
         platform="el/7")
+    assert len(release_versions) == 2 and release_versions == ['13', '14']
+    assert len(nightly_versions) == 3 and nightly_versions == ['13', '14', '15']
+
+
+def test_get_postgres_versions_debain_bullseye():
+    release_versions, nightly_versions = get_postgres_versions(
+        input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
+        platform="debian/bullseye")
     assert len(release_versions) == 2 and release_versions == ['13', '14']
     assert len(nightly_versions) == 3 and nightly_versions == ['13', '14', '15']
 

--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -91,11 +91,6 @@ def test_delete_rpm_key_by_name():
 
 def test_get_postgres_versions():
     release_versions, nightly_versions = get_postgres_versions(
-        platform="debian/buster",
-        input_files_dir=f"{TEST_BASE_PATH}/packaging_automation/tests/files")
-    assert release_versions[0] == "all" and nightly_versions[0] == "all"
-
-    release_versions, nightly_versions = get_postgres_versions(
         platform="el/8",
         input_files_dir=f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions == ["11", "12", "13"] and nightly_versions == ["12", "13", "14"]

--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -90,8 +90,8 @@ def test_delete_rpm_key_by_name():
 
 
 def test_get_postgres_versions():
-    release_versions, nightly_versions = get_postgres_versions(os_name="debian", platform="debian/buster"
-                                                                                          f"{TEST_BASE_PATH}/packaging_automation/tests/files")
+    release_versions, nightly_versions = get_postgres_versions(os_name="debian", platform="debian/buster",
+                                                               input_files_dir=f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions[0] == "all" and nightly_versions[0] == "all"
 
     release_versions, nightly_versions = get_postgres_versions(os_name="el", platform="el/8",

--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -90,12 +90,12 @@ def test_delete_rpm_key_by_name():
 
 
 def test_get_postgres_versions():
-    release_versions, nightly_versions = get_postgres_versions("debian",
-                                                               f"{TEST_BASE_PATH}/packaging_automation/tests/files")
+    release_versions, nightly_versions = get_postgres_versions("debian", "debian,buster"
+                                                                         f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions[0] == "all" and nightly_versions[0] == "all"
 
-    release_versions, nightly_versions = get_postgres_versions("el",
-                                                               f"{TEST_BASE_PATH}/packaging_automation/tests/files")
+    release_versions, nightly_versions = get_postgres_versions("el", "el,8"
+                                                                     f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions == ["11", "12", "13"] and nightly_versions == ["12", "13", "14"]
 
 

--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -110,7 +110,6 @@ def test_build_package_debian():
                   docker_platform="debian-stretch", postgres_version="all",
                   input_output_parameters=input_output_parameters, is_test=True)
 
-
 def test_build_package_rpm():
     input_output_parameters = InputOutputParameters.build(PACKAGING_EXEC_FOLDER, f"{OUTPUT_FOLDER}/debian-stretch",
                                                           output_validation=False)

--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -90,11 +90,11 @@ def test_delete_rpm_key_by_name():
 
 
 def test_get_postgres_versions():
-    release_versions, nightly_versions = get_postgres_versions("debian", "debian,buster"
-                                                                         f"{TEST_BASE_PATH}/packaging_automation/tests/files")
+    release_versions, nightly_versions = get_postgres_versions(os_name="debian", platform="debian/buster"
+                                                                                          f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions[0] == "all" and nightly_versions[0] == "all"
 
-    release_versions, nightly_versions = get_postgres_versions("el", "el,8"
+    release_versions, nightly_versions = get_postgres_versions("el", "el/8"
                                                                      f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions == ["11", "12", "13"] and nightly_versions == ["12", "13", "14"]
 

--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -90,12 +90,14 @@ def test_delete_rpm_key_by_name():
 
 
 def test_get_postgres_versions():
-    release_versions, nightly_versions = get_postgres_versions(os_name="debian", platform="debian/buster",
-                                                               input_files_dir=f"{TEST_BASE_PATH}/packaging_automation/tests/files")
+    release_versions, nightly_versions = get_postgres_versions(
+        platform="debian/buster",
+        input_files_dir=f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions[0] == "all" and nightly_versions[0] == "all"
 
-    release_versions, nightly_versions = get_postgres_versions(os_name="el", platform="el/8",
-                                                               input_files_dir=f"{TEST_BASE_PATH}/packaging_automation/tests/files")
+    release_versions, nightly_versions = get_postgres_versions(
+        platform="el/8",
+        input_files_dir=f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions == ["11", "12", "13"] and nightly_versions == ["12", "13", "14"]
 
 
@@ -109,6 +111,7 @@ def test_build_package_debian():
     build_package(github_token=GH_TOKEN, build_type=BuildType.release,
                   docker_platform="debian-stretch", postgres_version="all",
                   input_output_parameters=input_output_parameters, is_test=True)
+
 
 def test_build_package_rpm():
     input_output_parameters = InputOutputParameters.build(PACKAGING_EXEC_FOLDER, f"{OUTPUT_FOLDER}/debian-stretch",

--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -94,8 +94,8 @@ def test_get_postgres_versions():
                                                                                           f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions[0] == "all" and nightly_versions[0] == "all"
 
-    release_versions, nightly_versions = get_postgres_versions("el", "el/8"
-                                                                     f"{TEST_BASE_PATH}/packaging_automation/tests/files")
+    release_versions, nightly_versions = get_postgres_versions(os_name="el", platform="el/8",
+                                                               input_files_dir=f"{TEST_BASE_PATH}/packaging_automation/tests/files")
     assert release_versions == ["11", "12", "13"] and nightly_versions == ["12", "13", "14"]
 
 


### PR DESCRIPTION
Currently, there is no mechanism to be able to  put an exception for ans os/release pair. With the pg_exclude.yml file, we can add exceptions for specific pg releases. If we set os/release pair as "all", all os/release pairs will be excluded