### PR TITLE
Fix prepare_release.py based on the changes made in Citus repo

### DIFF
--- a/packaging_automation/prepare_release.py
+++ b/packaging_automation/prepare_release.py
@@ -36,10 +36,10 @@ from .common_validations import CITUS_MINOR_VERSION_PATTERN, CITUS_PATCH_VERSION
 MULTI_EXTENSION_SQL = "src/test/regress/sql/multi_extension.sql"
 CITUS_CONTROL = "src/backend/distributed/citus.control"
 MULTI_EXTENSION_OUT = "src/test/regress/expected/multi_extension.out"
-CONFIG_PY = "src/test/regress/upgrade/config.py"
+CONFIG_PY = "src/test/regress/citus_tests/config.py"
 DISTRIBUTED_SQL_DIR_PATH = "src/backend/distributed/sql"
 DOWNGRADES_DIR_PATH = f"{DISTRIBUTED_SQL_DIR_PATH}/downgrades"
-CONFIGURE_IN = "configure.ac"
+CONFIGURE_AC = "configure.ac"
 CONFIGURE = "configure"
 CITUS_CONTROL_SEARCH_PATTERN = r"^default_version*"
 
@@ -57,9 +57,9 @@ MULTI_EXT_DETAIL2_PATTERN = (
     rf"^{MULTI_EXT_DETAIL_PREFIX}\d+\.\d+{MULTI_EXT_DETAIL2_SUFFIX}$"
 )
 
-CONFIG_PY_MASTER_VERSION_SEARCH_PATTERN = r"^MASTER_VERSION = '\d+\.\d+'"
+CONFIG_PY_MASTER_VERSION_SEARCH_PATTERN = r'^MASTER_VERSION = "\d+\.\d+"'
 
-CONFIGURE_IN_SEARCH_PATTERN = "AC_INIT*"
+CONFIGURE_AC_SEARCH_PATTERN = "AC_INIT*"
 REPO_OWNER = "citusdata"
 
 BASE_PATH = pathlib2.Path(__file__).parent.absolute()
@@ -69,7 +69,7 @@ MULTI_EXT_OUT_TEMPLATE_FILE = "multi_extension_out_prepare_release.tmpl"
 MULTI_EXT_SQL_TEMPLATE_FILE = "multi_extension_sql_prepare_release.tmpl"
 
 repo_details = {
-    "citus": {"configure-in-str": "Citus", "branch": "master"},
+    "citus": {"configure-in-str": "Citus", "branch": "main"},
     "citus-enterprise": {
         "configure-in-str": "Citus Enterprise",
         "branch": "enterprise-master",
@@ -187,7 +187,7 @@ def update_release(
         multi_extension_out_path=f"{exec_path}/{MULTI_EXTENSION_OUT}",
         multi_extension_sql_path=f"{exec_path}/{MULTI_EXTENSION_SQL}",
         citus_control_file_path=f"{exec_path}/{CITUS_CONTROL}",
-        configure_in_path=f"{exec_path}/{CONFIGURE_IN}",
+        configure_in_path=f"{exec_path}/{CONFIGURE_AC}",
         config_py_path=f"{exec_path}/{CONFIG_PY}",
         distributed_dir_path=f"{exec_path}/{DISTRIBUTED_SQL_DIR_PATH}",
         downgrades_dir_path=f"{exec_path}/{DOWNGRADES_DIR_PATH}",
@@ -560,12 +560,13 @@ def add_downgrade_script_in_multi_extension_file(
 
     if not prepend_line_in_file(
         multi_extension_out_path,
-        "DROP TABLE prev_objects, extension_diff;",
+        "DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;",
         string_to_prepend,
     ):
         raise ValueError(
             f"Downgrade scripts could not be added in {multi_extension_out_path} since "
-            f"'DROP TABLE prev_objects, extension_diff;' script could not be found  "
+            "'DROP TABLE multi_extension.prev_objects, multi_extension.extension_diff;' "
+            "script could not be found  "
         )
     print(
         f"### Done Test downgrade scripts successfully  added in {multi_extension_out_path}. ###"
@@ -696,7 +697,7 @@ def update_version_in_configure_in(project_name, configure_in_path, project_vers
     print(f"### Updating version on file {configure_in_path}... ###")
     if not replace_line_in_file(
         configure_in_path,
-        CONFIGURE_IN_SEARCH_PATTERN,
+        CONFIGURE_AC_SEARCH_PATTERN,
         f"AC_INIT([{repo_details[project_name]['configure-in-str']}], [{project_version}])",
     ):
         raise ValueError(f"{configure_in_path} does not have match for version")

--- a/packaging_automation/prepare_release.py
+++ b/packaging_automation/prepare_release.py
@@ -39,7 +39,7 @@ MULTI_EXTENSION_OUT = "src/test/regress/expected/multi_extension.out"
 CONFIG_PY = "src/test/regress/upgrade/config.py"
 DISTRIBUTED_SQL_DIR_PATH = "src/backend/distributed/sql"
 DOWNGRADES_DIR_PATH = f"{DISTRIBUTED_SQL_DIR_PATH}/downgrades"
-CONFIGURE_IN = "configure.in"
+CONFIGURE_IN = "configure.ac"
 CONFIGURE = "configure"
 CITUS_CONTROL_SEARCH_PATTERN = r"^default_version*"
 
@@ -321,7 +321,7 @@ def prepare_release_branch_for_patch_release(patchReleaseParams: PatchReleasePar
         checkout_branch(
             patchReleaseParams.release_branch_name, patchReleaseParams.is_test
         )
-    # change version info in configure.in file
+    # change version info in configure.ac file
     update_version_in_configure_in(
         patchReleaseParams.project_name,
         patchReleaseParams.configure_in_path,
@@ -368,7 +368,7 @@ def prepare_upcoming_version_branch(upcoming_params: UpcomingVersionBranchParams
     checkout_branch(upcoming_params.main_branch, upcoming_params.is_test)
     # create master-update-version-$curtime branch
     create_and_checkout_branch(upcoming_params.upcoming_version_branch)
-    # update version info with upcoming version on configure.in
+    # update version info with upcoming version on configure.ac
     update_version_in_configure_in(
         upcoming_params.project_name,
         upcoming_params.configure_in_path,
@@ -450,7 +450,7 @@ def prepare_release_branch_for_major_release(majorReleaseParams: MajorReleasePar
     checkout_branch(majorReleaseParams.main_branch, majorReleaseParams.is_test)
     # create release branch in release-X.Y format
     create_and_checkout_branch(majorReleaseParams.release_branch_name)
-    # change version info in configure.in file
+    # change version info in configure.ac file
     update_version_in_configure_in(
         majorReleaseParams.project_name,
         majorReleaseParams.configure_in_path,

--- a/packaging_automation/templates/multi_extension_out_prepare_release.tmpl
+++ b/packaging_automation/templates/multi_extension_out_prepare_release.tmpl
@@ -2,14 +2,14 @@
 ALTER EXTENSION citus UPDATE TO '{{upcoming_minor_version}}';
 ALTER EXTENSION citus UPDATE TO '{{current_schema_version}}';
 -- Should be empty result since upgrade+downgrade should be a no-op
-SELECT * FROM print_extension_changes();
+SELECT * FROM multi_extension.print_extension_changes();
  previous_object | current_object
 ---------------------------------------------------------------------
 (0 rows)
 
 -- Snapshot of state at {{upcoming_minor_version}}
 ALTER EXTENSION citus UPDATE TO '{{upcoming_minor_version}}';
-SELECT * FROM print_extension_changes();
+SELECT * FROM multi_extension.print_extension_changes();
  previous_object | current_object
 ---------------------------------------------------------------------
 (0 rows)

--- a/packaging_automation/templates/multi_extension_sql_prepare_release.tmpl
+++ b/packaging_automation/templates/multi_extension_sql_prepare_release.tmpl
@@ -2,8 +2,8 @@
 ALTER EXTENSION citus UPDATE TO '{{upcoming_minor_version}}';
 ALTER EXTENSION citus UPDATE TO '{{current_schema_version}}';
 -- Should be empty result since upgrade+downgrade should be a no-op
-SELECT * FROM print_extension_changes();
+SELECT * FROM multi_extension.print_extension_changes();
 
 -- Snapshot of state at {{upcoming_minor_version}}
 ALTER EXTENSION citus UPDATE TO '{{upcoming_minor_version}}';
-SELECT * FROM print_extension_changes();
+SELECT * FROM multi_extension.print_extension_changes();

--- a/packaging_automation/tests/test_prepare_release.py
+++ b/packaging_automation/tests/test_prepare_release.py
@@ -16,7 +16,7 @@ from ..prepare_release import (
     MULTI_EXTENSION_OUT,
     MULTI_EXTENSION_SQL,
     CONFIGURE,
-    CONFIGURE_IN,
+    CONFIGURE_AC,
     CITUS_CONTROL,
     CONFIG_PY,
     ProjectParams,
@@ -74,7 +74,7 @@ def test_major_release():
 
     assert file_includes_line(test_base_path_major, MULTI_EXTENSION_OUT, " 10.1.0")
     assert file_includes_line(
-        test_base_path_major, CONFIGURE_IN, "AC_INIT([Citus], [10.1.0])"
+        test_base_path_major, CONFIGURE_AC, "AC_INIT([Citus], [10.1.0])"
     )
     assert file_includes_line(
         test_base_path_major, CONFIGURE, "PACKAGE_VERSION='10.1.0'"
@@ -154,7 +154,7 @@ def test_major_release():
         test_base_path_major, CONFIG_PY, "MASTER_VERSION = '10.2'"
     )
     assert file_includes_line(
-        test_base_path_major, CONFIGURE_IN, "AC_INIT([Citus], [10.2devel])"
+        test_base_path_major, CONFIGURE_AC, "AC_INIT([Citus], [10.2devel])"
     )
     assert file_includes_line(
         test_base_path_major, CONFIGURE, "PACKAGE_VERSION='10.2devel'"
@@ -213,7 +213,7 @@ def test_patch_release():
         )
         assert file_includes_line(
             test_base_path_patch,
-            CONFIGURE_IN,
+            CONFIGURE_AC,
             f"AC_INIT([Citus], [{project_params.project_version}])",
         )
         assert file_includes_line(


### PR DESCRIPTION
The following changes were made in Citus repo in the past two releases:
* config.py is moved into a different directory
* confifure.in is renamed to configure.ac
* MASTER_VERSION string constant now uses double quotes instead of single quotes
* Development branch is renamed to "main"
* multi_extension.sql now needs to call some utility functions and needs to drop the temporary tables by qualifying their schemas