### PR TITLE
Adds support for debian/bookworm,ubuntu/kinetic

### DIFF
--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -41,6 +41,7 @@ docker_image_names = {
 package_docker_platform_dict = {
     "centos,8": "el/8",
     "centos,7": "el/7",
+    "debian,bookworm": "debian/bookworm",
     "debian,bullseye": "debian/bullseye",
     "debian,buster": "debian/buster",
     "debian,stretch": "debian/stretch",
@@ -50,6 +51,7 @@ package_docker_platform_dict = {
     "ubuntu,focal": "ubuntu/focal",
     "ubuntu,bionic": "ubuntu/bionic",
     "ubuntu,jammy": "ubuntu/jammy",
+    "ubuntu,kinetic": "ubuntu/kinetic",
     "pgxn": "pgxn"
 }
 

--- a/packaging_automation/common_tool_methods.py
+++ b/packaging_automation/common_tool_methods.py
@@ -37,10 +37,10 @@ DEFAULT_UNICODE_ERROR_HANDLER = "surrogateescape"
 referenced_repos: List[Repo] = []
 
 supported_platforms = {
-    "debian": ["bullseye", "buster", "stretch", "jessie", "wheezy"],
+    "debian": ["bookworm", "bullseye", "buster", "stretch", "jessie", "wheezy"],
     "el": ["8", "7", "6"],
     "ol": ["7", "8"],
-    "ubuntu": ["focal", "bionic", "trusty","jammy"]
+    "ubuntu": ["focal", "bionic", "trusty", "jammy", "kinetic"]
 }
 
 
@@ -395,7 +395,7 @@ def remove_cloned_code(exec_path: str):
 
 
 def process_template_file_with_minor(project_version: str, templates_path: str, template_file_path: str,
-                                     minor_version: str,postgres_version: str = ""):
+                                     minor_version: str, postgres_version: str = ""):
     ''' This function gets the template files, changes tha parameters inside the file and returns the output.
         Template files are stored under packaging_automation/templates and these files include parametric items in the
         format of {{parameter_name}}. This function is used while creating docker files and pgxn files which include

--- a/packaging_automation/test_citus_package.py
+++ b/packaging_automation/test_citus_package.py
@@ -28,12 +28,14 @@ class TestPlatform(Enum):
     centos_7 = {"name": "centos/7", "docker_image_name": "centos-7"}
     ol_7 = {"name": "ol/7", "docker_image_name": "ol-7"}
     ol_8 = {"name": "ol/8", "docker_image_name": "ol-8"}
-    debian_buster = {"name": "debian/buster", "docker_image_name": "debian-buster", }
-    debian_bullseye = {"name": "debian/bullseye", "docker_image_name": "debian-bullseye"}
     debian_stretch = {"name": "debian/stretch", "docker_image_name": "debian-stretch"}
+    debian_buster = {"name": "debian/buster", "docker_image_name": "debian-buster"}
+    debian_bullseye = {"name": "debian/bullseye", "docker_image_name": "debian-bullseye"}
+    debian_bookworm = {"name": "debian/bookworm", "docker_image_name": "debian-bookworm"}
     ubuntu_bionic = {"name": "ubuntu/bionic", "docker_image_name": "ubuntu-bionic"}
     ubuntu_focal = {"name": "ubuntu/focal", "docker_image_name": "ubuntu-focal"}
     ubuntu_jammy = {"name": "ubuntu/jammy", "docker_image_name": "ubuntu-jammy"}
+    ubuntu_kinetic = {"name": "ubuntu/kinetic", "docker_image_name": "ubuntu-kinetic"}
     undefined = {"name": "undefined", "docker_image_name": "undefined"}
 
 
@@ -76,7 +78,6 @@ if __name__ == "__main__":
 
     if args.pg_major_version:
         postgres_versions = [p for p in postgres_versions if p == args.pg_major_version]
-
 
     if len(postgres_versions) == 0:
         raise ValueError("At least one supported postgres version is required")

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -31,9 +31,11 @@ single_postgres_package_counts = {
     "debian/stretch": 2,
     "debian/buster": 2,
     "debian/bullseye": 2,
+    "debian/bookworm": 2,
     "ubuntu/bionic": 2,
     "ubuntu/focal": 2,
-    "ubuntu/jammy": 2
+    "ubuntu/jammy": 2,
+    "ubuntu/kinetic": 2
 }
 
 TEST_GPG_KEY_NAME = "Citus Data <packaging@citusdata.com>"

--- a/packaging_automation/upload_to_package_cloud.py
+++ b/packaging_automation/upload_to_package_cloud.py
@@ -14,12 +14,15 @@ supported_distros = {
     "el/8": 205,
     "ol/7": 146,
     "ol/8": 234,
-    "debian/bullseye": 207,
-    "debian/buster": 150,
     "debian/stretch": 149,
-    "ubuntu/focal": 210,
+    "debian/buster": 150,
+    "debian/bullseye": 207,
+    "debian/bookworm": 215,
     "ubuntu/bionic": 190,
-    "ubuntu/jammy": 237
+    "ubuntu/focal": 210,
+    "ubuntu/jammy": 237,
+    # TODO: Ubuntu kinetic is not supported yet in packagecloud. We should add it, when it is supported
+    # "ubuntu/kinetic": xxx
 }
 
 supported_repos = ["citus-bot/sample",


### PR DESCRIPTION
Ubuntu/kinetic packagecloud support is not ready yet. After packagecloud support for ubuntu/kinetic, code should be added.

I could not add ubuntu/kinetic docker image either, since deb images depends on packagecloud and packagecloud does not have ubuntu/kinetic support yet.
However, still I want to keep the changes since I have meeting to add the support.