### PR TITLE
Adds ubuntu/kinetic packagecloud code

### DIFF
--- a/packaging_automation/upload_to_package_cloud.py
+++ b/packaging_automation/upload_to_package_cloud.py
@@ -23,8 +23,7 @@ supported_distros = {
     "ubuntu/bionic": 190,
     "ubuntu/focal": 210,
     "ubuntu/jammy": 237,
-    # TODO: Ubuntu kinetic is not supported yet in packagecloud. We should add it, when it is supported
-    # "ubuntu/kinetic": xxx
+    "ubuntu/kinetic": 261
 }
 
 supported_repos = ["citus-bot/sample",


### PR DESCRIPTION
Below is the response from packagecloud distro list api for Ubuntu kinetic. I added the code 261 to upload packages to packagecloud
        {
          "id": 261,
          "display_name": "22.10 Kinetic Kudu",
          "index_name": "kinetic",
          "version_number": "22.10"
        }