### PR TITLE
Update columnar migration version on prepare_release

### DIFF
--- a/packaging_automation/prepare_release.py
+++ b/packaging_automation/prepare_release.py
@@ -38,8 +38,10 @@ CITUS_CONTROL = "src/backend/distributed/citus.control"
 COLUMNAR_CONTROL = "src/backend/columnar/citus_columnar.control"
 MULTI_EXTENSION_OUT = "src/test/regress/expected/multi_extension.out"
 CONFIG_PY = "src/test/regress/upgrade/config.py"
-DISTRIBUTED_SQL_DIR_PATH = "src/backend/distributed/sql"
-DOWNGRADES_DIR_PATH = f"{DISTRIBUTED_SQL_DIR_PATH}/downgrades"
+CITUS_SQL_DIR_PATH = "src/backend/distributed/sql"
+CITUS_DOWNGRADES_DIR_PATH = f"{CITUS_SQL_DIR_PATH}/downgrades"
+COLUMNAR_SQL_DIR_PATH = "src/backend/columnar/sql"
+COLUMNAR_DOWNGRADES_DIR_PATH = f"{COLUMNAR_SQL_DIR_PATH}/downgrades"
 CONFIGURE_IN = "configure.in"
 CONFIGURE = "configure"
 CONTROL_FILE_SEARCH_PATTERN = r"^default_version*"
@@ -82,8 +84,10 @@ repo_details = {
 class UpdateReleaseReturnValue:
     release_branch_name: str
     upcoming_version_branch: str
-    upgrade_path_sql_file: str
-    downgrade_path_sql_file: str
+    citus_upgrade_path_sql_file: str
+    columnar_upgrade_path_sql_file: str
+    citus_downgrade_path_sql_file: str
+    columnar_downgrade_path_sql_file: str
 
 
 @dataclass
@@ -105,8 +109,10 @@ class UpcomingVersionBranchParams:
     config_py_path: str
     configure_in_path: str
     upcoming_devel_version: str
-    distributed_dir_path: str
-    downgrades_dir_path: str
+    citus_sql_dir_path: str
+    columnar_sql_dir_path: str
+    citus_downgrades_dir_path: str
+    columnar_downgrades_dir_path: str
     is_test: bool
     main_branch: str
     multi_extension_out_path: str
@@ -151,8 +157,10 @@ class PathParams:
     multi_extension_out_path: str
     configure_in_path: str
     config_py_path: str
-    distributed_dir_path: str
-    downgrades_dir_path: str
+    citus_sql_dir_path: str
+    columnar_sql_dir_path: str
+    citus_downgrades_dir_path: str
+    columnar_downgrades_dir_path: str
 
 
 @dataclass
@@ -173,8 +181,10 @@ BASE_GIT_PATH = pathlib2.Path(__file__).parents[1]
 
 @dataclass
 class MigrationFiles:
-    upgrade_file: str
-    downgrade_file: str
+    citus_upgrade_file: str
+    citus_downgrade_file: str
+    columnar_upgrade_file: str
+    columnar_downgrade_file: str
 
 
 # disabled since this is related to parameter_validations library methods
@@ -194,8 +204,10 @@ def update_release(
         columnar_control_file_path=f"{exec_path}/{COLUMNAR_CONTROL}",
         configure_in_path=f"{exec_path}/{CONFIGURE_IN}",
         config_py_path=f"{exec_path}/{CONFIG_PY}",
-        distributed_dir_path=f"{exec_path}/{DISTRIBUTED_SQL_DIR_PATH}",
-        downgrades_dir_path=f"{exec_path}/{DOWNGRADES_DIR_PATH}",
+        citus_sql_dir_path=f"{exec_path}/{CITUS_SQL_DIR_PATH}",
+        columnar_sql_dir_path=f"{exec_path}/{COLUMNAR_SQL_DIR_PATH}",
+        citus_downgrades_dir_path=f"{exec_path}/{CITUS_DOWNGRADES_DIR_PATH}",
+        columnar_downgrades_dir_path=f"{exec_path}/{COLUMNAR_DOWNGRADES_DIR_PATH}",
     )
 
     version_params = VersionParams(
@@ -217,7 +229,7 @@ def update_release(
 
     upcoming_version_branch = ""
 
-    migration_files = MigrationFiles("", "")
+    migration_files = MigrationFiles("", "", "", "")
     # major release
     if is_major_release(project_params.project_version):
         print(
@@ -245,8 +257,10 @@ def update_release(
             columnar_control_file_path=path_params.columnar_control_file_path,
             config_py_path=path_params.config_py_path,
             configure_in_path=path_params.configure_in_path,
-            distributed_dir_path=path_params.distributed_dir_path,
-            downgrades_dir_path=path_params.downgrades_dir_path,
+            citus_sql_dir_path=path_params.citus_sql_dir_path,
+            columnar_sql_dir_path=path_params.columnar_sql_dir_path,
+            citus_downgrades_dir_path=path_params.citus_downgrades_dir_path,
+            columnar_downgrades_dir_path=path_params.columnar_downgrades_dir_path,
             repository=repository,
             upcoming_minor_version=version_params.upcoming_minor_version,
             multi_extension_out_path=path_params.multi_extension_out_path,
@@ -281,8 +295,10 @@ def update_release(
     return UpdateReleaseReturnValue(
         release_branch_name=branch_params.release_branch_name,
         upcoming_version_branch=upcoming_version_branch,
-        upgrade_path_sql_file=f"{DISTRIBUTED_SQL_DIR_PATH}/{migration_files.upgrade_file}",
-        downgrade_path_sql_file=f"{DOWNGRADES_DIR_PATH}/{migration_files.downgrade_file}",
+        citus_upgrade_path_sql_file=f"{CITUS_SQL_DIR_PATH}/{migration_files.citus_upgrade_file}",
+        columnar_upgrade_path_sql_file=f"{COLUMNAR_SQL_DIR_PATH}/{migration_files.columnar_upgrade_file}",
+        citus_downgrade_path_sql_file=f"{CITUS_DOWNGRADES_DIR_PATH}/{migration_files.citus_downgrade_file}",
+        columnar_downgrade_path_sql_file=f"{COLUMNAR_DOWNGRADES_DIR_PATH}/{migration_files.columnar_downgrade_file}",
     )
 
 
@@ -417,13 +433,15 @@ def prepare_upcoming_version_branch(upcoming_params: UpcomingVersionBranchParams
     # create a new sql file for upgrade path:
     upgrade_file = create_new_sql_for_upgrade_path(
         current_schema_version,
-        upcoming_params.distributed_dir_path,
+        upcoming_params.citus_sql_dir_path,
+        upcoming_params.columnar_sql_dir_path,
         upcoming_params.upcoming_minor_version,
     )
     # create a new sql file for downgrade path:
     downgrade_file = create_new_sql_for_downgrade_path(
         current_schema_version,
-        upcoming_params.downgrades_dir_path,
+        upcoming_params.citus_downgrades_dir_path,
+        upcoming_params.columnar_downgrades_dir_path,
         upcoming_params.upcoming_minor_version,
     )
 
@@ -735,45 +753,79 @@ def checkout_branch(branch_name, is_test):
     print(f"### Done {branch_name} checked out and pulled. ###")
 
 
-def upgrade_sql_file_name(current_schema_version, upcoming_minor_version):
-    return f"citus--{current_schema_version}--{upcoming_minor_version}-1.sql"
+def upgrade_sql_file_name(
+    extension_name, current_schema_version, upcoming_migration_version
+):
+    return f"{extension_name}--{current_schema_version}--{upcoming_migration_version}-1.sql"
 
 
 def create_new_sql_for_upgrade_path(
-    current_schema_version, distributed_dir_path, upcoming_minor_version
+    current_schema_version,
+    citus_sql_dir_path,
+    columnar_sql_dir_path,
+    upcoming_minor_version,
 ):
-    newly_created_sql_file = upgrade_sql_file_name(
-        current_schema_version, upcoming_minor_version
+    extension_name = "citus"
+    new_citus_upgrade_sql_file = upgrade_sql_file_name(
+        extension_name, current_schema_version, upcoming_minor_version
     )
-    print(f"### Creating upgrade file {newly_created_sql_file}... ###")
+    print(f"### Creating upgrade file {new_citus_upgrade_sql_file}... ###")
     with open(
-        f"{distributed_dir_path}/{newly_created_sql_file}",
+        f"{citus_sql_dir_path}/{new_citus_upgrade_sql_file}",
         "w",
         encoding=DEFAULT_ENCODING_FOR_FILE_HANDLING,
         errors=DEFAULT_UNICODE_ERROR_HANDLER,
     ) as f_writer:
-        content = f"-- citus--{current_schema_version}--{upcoming_minor_version}-1"
+        content = (
+            f"-- {extension_name}--{current_schema_version}--{upcoming_minor_version}-1"
+        )
         content = content + "\n\n"
         content = content + f"-- bump version to {upcoming_minor_version}-1" + "\n\n"
         f_writer.write(content)
-    print(f"### Done {newly_created_sql_file} created. ###")
-    return newly_created_sql_file
+    print(f"### Done {new_citus_upgrade_sql_file} created. ###")
 
-
-def create_new_sql_for_downgrade_path(
-    current_schema_version, distributed_dir_path, upcoming_minor_version
-):
-    newly_created_sql_file = (
-        f"citus--{upcoming_minor_version}-1--{current_schema_version}.sql"
+    extension_name = "columnar"
+    new_columnar_upgrade_sql_file = upgrade_sql_file_name(
+        extension_name, current_schema_version, upcoming_minor_version
     )
-    print(f"### Creating downgrade file {newly_created_sql_file}... ###")
+    print(f"### Creating upgrade file {new_columnar_upgrade_sql_file}... ###")
     with open(
-        f"{distributed_dir_path}/{newly_created_sql_file}",
+        f"{columnar_sql_dir_path}/{new_columnar_upgrade_sql_file}",
         "w",
         encoding=DEFAULT_ENCODING_FOR_FILE_HANDLING,
         errors=DEFAULT_UNICODE_ERROR_HANDLER,
     ) as f_writer:
-        content = f"-- citus--{upcoming_minor_version}-1--{current_schema_version}"
+        content = (
+            f"-- {extension_name}--{current_schema_version}--{upcoming_minor_version}-1"
+        )
+        content = content + "\n\n"
+        content = content + f"-- bump version to {upcoming_minor_version}-1" + "\n\n"
+        f_writer.write(content)
+    print(f"### Done {new_columnar_upgrade_sql_file} created. ###")
+
+    return new_citus_upgrade_sql_file, new_columnar_upgrade_sql_file
+
+
+def create_new_sql_for_downgrade_path(
+    current_schema_version,
+    citus_sql_dir_path,
+    columnar_sql_dir_path,
+    upcoming_minor_version,
+):
+    extension_name = "citus"
+    new_citus_downgrade_sql_file = upgrade_sql_file_name(
+        extension_name, upcoming_minor_version, current_schema_version
+    )
+    print(f"### Creating downgrade file {new_citus_downgrade_sql_file}... ###")
+    with open(
+        f"{citus_sql_dir_path}/{new_citus_downgrade_sql_file}",
+        "w",
+        encoding=DEFAULT_ENCODING_FOR_FILE_HANDLING,
+        errors=DEFAULT_UNICODE_ERROR_HANDLER,
+    ) as f_writer:
+        content = (
+            f"-- {extension_name}--{upcoming_minor_version}-1--{current_schema_version}"
+        )
         content = content + "\n"
         content = (
             content + f"-- this is an empty downgrade path since "
@@ -781,8 +833,33 @@ def create_new_sql_for_downgrade_path(
             f"is empty for now" + "\n"
         )
         f_writer.write(content)
-    print(f"### Done {newly_created_sql_file} created. ###")
-    return newly_created_sql_file
+    print(f"### Done {new_citus_downgrade_sql_file} created. ###")
+
+    extension_name = "columnar"
+    new_columnar_downgrade_sql_file = upgrade_sql_file_name(
+        extension_name, upcoming_minor_version, current_schema_version
+    )
+
+    print(f"### Creating downgrade file {new_columnar_downgrade_sql_file}... ###")
+    with open(
+        f"{columnar_sql_dir_path}/{new_columnar_downgrade_sql_file}",
+        "w",
+        encoding=DEFAULT_ENCODING_FOR_FILE_HANDLING,
+        errors=DEFAULT_UNICODE_ERROR_HANDLER,
+    ) as f_writer:
+        content = (
+            f"-- {extension_name}--{upcoming_minor_version}-1--{current_schema_version}"
+        )
+        content = content + "\n"
+        content = (
+            content + f"-- this is an empty downgrade path since "
+            f"{upgrade_sql_file_name(extension_name, current_schema_version, upcoming_minor_version)} "
+            f"is empty for now" + "\n"
+        )
+        f_writer.write(content)
+    print(f"### Done {new_columnar_downgrade_sql_file} created. ###")
+
+    return new_citus_downgrade_sql_file, new_columnar_downgrade_sql_file
 
 
 CHECKOUT_DIR = "citus_temp"

--- a/packaging_automation/prepare_release.py
+++ b/packaging_automation/prepare_release.py
@@ -430,15 +430,15 @@ def prepare_upcoming_version_branch(upcoming_params: UpcomingVersionBranchParams
         upcoming_params.upcoming_minor_version,
         MULTI_EXT_OUT_TEMPLATE_FILE,
     )
-    # create a new sql file for upgrade path:
-    upgrade_file = create_new_sql_for_upgrade_path(
+    # create new sql files for upgrade path:
+    citus_upgrade_file, columnar_upgrade_file = create_new_sql_for_upgrade_path(
         current_schema_version,
         upcoming_params.citus_sql_dir_path,
         upcoming_params.columnar_sql_dir_path,
         upcoming_params.upcoming_minor_version,
     )
-    # create a new sql file for downgrade path:
-    downgrade_file = create_new_sql_for_downgrade_path(
+    # create new sql files for downgrade path:
+    citus_downgrade_file, columnar_downgrade_file = create_new_sql_for_downgrade_path(
         current_schema_version,
         upcoming_params.citus_downgrades_dir_path,
         upcoming_params.columnar_downgrades_dir_path,
@@ -467,7 +467,12 @@ def prepare_upcoming_version_branch(upcoming_params: UpcomingVersionBranchParams
             upcoming_params.upcoming_devel_version,
         )
     print(f"### Done {upcoming_params.upcoming_version_branch} flow executed. ###")
-    return MigrationFiles(upgrade_file=upgrade_file, downgrade_file=downgrade_file)
+    return MigrationFiles(
+        citus_upgrade_file=citus_upgrade_file,
+        columnar_upgrade_file=columnar_upgrade_file,
+        citus_downgrade_file=citus_downgrade_file,
+        columnar_downgrade_file=columnar_downgrade_file,
+    )
 
 
 def prepare_release_branch_for_major_release(majorReleaseParams: MajorReleaseParams):


### PR DESCRIPTION
This PR aims to contain all the changes to automate what we did in https://github.com/citusdata/citus/pull/6898 to bump columnar versions in all the necessary places when we prepare a new release.

TODO:
- [x] update `citus_columnar.control`
- [x] create new upgrade and downgrade files for the new columnar migration version
- [x] Either add the logic to update diff changes here, or open a PR on citus to make sure the test outputs do not change when we bump columnar version
- [ ] consider adding tests to cover the columnar version bumps