### PR TITLE
Feature: citus_dev pipenv shebang

### DIFF
--- a/citus_dev/Pipfile
+++ b/citus_dev/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+docopt = "==0.6.2"
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/citus_dev/Pipfile.lock
+++ b/citus_dev/Pipfile.lock
@@ -1,0 +1,28 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "c004951b368351a7c39d61f2b952588df9e801b1fa377f59a2d7d714dbe20e02"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "index": "pypi",
+            "version": "==0.6.2"
+        }
+    },
+    "develop": {}
+}

--- a/citus_dev/citus_dev
+++ b/citus_dev/citus_dev
@@ -1,4 +1,4 @@
-#!/usr/bin/env pipenv-shebang
+#!/usr/bin/env python3
 """citus_dev
 
 Usage:

--- a/citus_dev/citus_dev
+++ b/citus_dev/citus_dev
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pipenv-shebang
 """citus_dev
 
 Usage:

--- a/citus_dev/citus_dev-pipenv
+++ b/citus_dev/citus_dev-pipenv
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# mostly copied from pipenv-shebang, but hardcoded for citus_dev
+function getPipfile() {
+  DIR="$(dirname "$1")"
+  if [[ $DIR == "/" ]]; then exit; fi
+  PIPFILE="$DIR/Pipfile"
+  if [[ -e "$PIPFILE" ]]; then
+    echo "$PIPFILE"
+  else
+    getPipfile "$DIR"
+  fi
+}
+
+SCRIPT="$(realpath "$0")"
+DIRNAME="$(dirname "$SCRIPT")"
+PIPFILE=$(getPipfile "$SCRIPT")
+
+if [[ -n "$PIPFILE" ]]; then
+  PIPENV_PIPFILE="$PIPFILE" exec pipenv run "${DIRNAME}/citus_dev" "$@"
+else
+  echo "Could not locate the Pipfile for citus_dev."
+  exit 1
+fi

--- a/citus_dev/citus_dev-pipenv
+++ b/citus_dev/citus_dev-pipenv
@@ -1,24 +1,4 @@
 #!/usr/bin/env bash
-
-# mostly copied from pipenv-shebang, but hardcoded for citus_dev
-function getPipfile() {
-  DIR="$(dirname "$1")"
-  if [[ $DIR == "/" ]]; then exit; fi
-  PIPFILE="$DIR/Pipfile"
-  if [[ -e "$PIPFILE" ]]; then
-    echo "$PIPFILE"
-  else
-    getPipfile "$DIR"
-  fi
-}
-
-SCRIPT="$(realpath "$0")"
-DIRNAME="$(dirname "$SCRIPT")"
-PIPFILE=$(getPipfile "$SCRIPT")
-
-if [[ -n "$PIPFILE" ]]; then
-  PIPENV_PIPFILE="$PIPFILE" exec pipenv run "${DIRNAME}/citus_dev" "$@"
-else
-  echo "Could not locate the Pipfile for citus_dev."
-  exit 1
-fi
+realfile=$(realpath $0)
+dir=$(dirname $realfile)
+pipenv-shebang "${dir}/citus_dev" "$@"


### PR DESCRIPTION
This adds a second script next to `citus_dev`. When a user doesn't want/can install the requirements globally they can opt to install `pipenv` + `pipenv-shebang` and link `citus_dev` on their path to `citus_dev-pipenv` to run the script in its isolated environment.

If the user opts to use `citus_dev-pipenv` it is their responsibility to `pipenv install` or `pipenv sync` in the source directory to make sure the environment is initialized correctly.