### PR TITLE
Updating supported platform list

### DIFF
--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -23,14 +23,17 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - el/7
           - el/8
-          - ol/7
+          - el/9
           - ol/8
-          - debian/stretch
+          - ol/9
+          - debian/buster
+          - debian/bookworm
+          - debian/trixie
           - debian/bullseye
-          - ubuntu/bionic
+          - ubuntu/bionjammy
           - ubuntu/focal
+          - ubuntu/noble
     env:
       PLATFORM: ${{ matrix.platform }}
 

--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -31,7 +31,7 @@ jobs:
           - debian/bookworm
           - debian/trixie
           - debian/bullseye
-          - ubuntu/bionjammy
+          - ubuntu/jammy
           - ubuntu/focal
           - ubuntu/noble
     env:

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -35,12 +35,7 @@ POSTGRES_MATRIX_FILE_NAME = "postgres-matrix.yml"
 POSTGRES_EXCLUDE_FILE_NAME = "pg_exclude.yml"
 
 docker_image_names = {
-    "almalinux": "almalinux",
-    "rockylinux": "almalinux",
     "debian": "debian",
-    "el/9": "almalinux-9",
-    "ol/9": "almalinux-9",
-    "el/8": "almalinux-8",
     "el": "centos",
     "ol": "oraclelinux",
     "ubuntu": "ubuntu",
@@ -48,21 +43,15 @@ docker_image_names = {
 }
 
 package_docker_platform_dict = {
-    "almalinux,9": "almalinux/9",
-    "almalinux,8": "almalinux/8",
     "centos,8": "el/8",
-    "centos,7": "el/7",
+    "centos,9": "el/9",
     "debian,trixie": "debian/trixie",
     "debian,bookworm": "debian/bookworm",
     "debian,bullseye": "debian/bullseye",
-    "debian,stretch": "debian/stretch",
     "oraclelinux,8": "ol/8",
-    "oraclelinux,7": "ol/7",
-    "oraclelinux,6": "ol/6",
+    "oraclelinux,9": "ol/9",
     "ubuntu,focal": "ubuntu/focal",
-    "ubuntu,bionic": "ubuntu/bionic",
     "ubuntu,jammy": "ubuntu/jammy",
-    "ubuntu,kinetic": "ubuntu/kinetic",
     "ubuntu,noble": "ubuntu/noble",
     "pgxn": "pgxn",
 }

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -52,6 +52,7 @@ package_docker_platform_dict = {
     "almalinux,8": "almalinux/8",
     "centos,8": "el/8",
     "centos,7": "el/7",
+    "debian,trixie": "debian/trixie",
     "debian,bookworm": "debian/bookworm",
     "debian,bullseye": "debian/bullseye",
     "debian,stretch": "debian/stretch",

--- a/packaging_automation/common_tool_methods.py
+++ b/packaging_automation/common_tool_methods.py
@@ -37,11 +37,11 @@ DEFAULT_UNICODE_ERROR_HANDLER = "surrogateescape"
 referenced_repos: List[Repo] = []
 
 supported_platforms = {
-    "debian": ["bookworm", "bullseye", "buster", "stretch", "jessie", "wheezy"],
+    "debian": ["trixie", "bookworm", "bullseye", "buster"],
     "almalinux": ["8", "9"],
-    "el": ["9", "8", "7", "6"],
-    "ol": ["9", "8", "7"],
-    "ubuntu": ["focal", "bionic", "trusty", "jammy", "kinetic", "noble"],
+    "el": ["9", "8"],
+    "ol": ["9", "8"],
+    "ubuntu": ["focal", "jammy", "noble"],
 }
 
 

--- a/packaging_automation/test_citus_package.py
+++ b/packaging_automation/test_citus_package.py
@@ -27,15 +27,10 @@ def run_command(command: str) -> int:
 
 
 class TestPlatform(Enum):
-    el_7 = {"name": "el/7", "docker_image_name": "el-7"}
     el_8 = {"name": "el/8", "docker_image_name": "el-8"}
     el_9 = {"name": "el/9", "docker_image_name": "almalinux-9"}
-    centos_8 = {"name": "centos/8", "docker_image_name": "centos-8"}
-    centos_7 = {"name": "centos/7", "docker_image_name": "centos-7"}
-    ol_7 = {"name": "ol/7", "docker_image_name": "ol-7"}
     ol_8 = {"name": "ol/8", "docker_image_name": "ol-8"}
     ol_9 = {"name": "ol/9", "docker_image_name": "ol-9"}
-    debian_stretch = {"name": "debian/stretch", "docker_image_name": "debian-stretch"}
     debian_buster = {"name": "debian/buster", "docker_image_name": "debian-buster"}
     debian_bullseye = {
         "name": "debian/bullseye",
@@ -45,10 +40,10 @@ class TestPlatform(Enum):
         "name": "debian/bookworm",
         "docker_image_name": "debian-bookworm",
     }
-    ubuntu_bionic = {"name": "ubuntu/bionic", "docker_image_name": "ubuntu-bionic"}
+    debian_trixie = {"name": "debian/trixie", "docker_image_name": "debian-trixie"}
     ubuntu_focal = {"name": "ubuntu/focal", "docker_image_name": "ubuntu-focal"}
     ubuntu_jammy = {"name": "ubuntu/jammy", "docker_image_name": "ubuntu-jammy"}
-    ubuntu_kinetic = {"name": "ubuntu/kinetic", "docker_image_name": "ubuntu-kinetic"}
+    ubuntu_noble = {"name": "ubuntu/noble", "docker_image_name": "ubuntu-noble"}
     undefined = {"name": "undefined", "docker_image_name": "undefined"}
 
 

--- a/packaging_automation/tests/files/get_postgres_versions_tests/pg_exclude.yml
+++ b/packaging_automation/tests/files/get_postgres_versions_tests/pg_exclude.yml
@@ -2,4 +2,4 @@ exclude:
   nightly:
     ol/7: [15]
   release:
-    all: []
+    all: [15]

--- a/packaging_automation/tests/files/get_postgres_versions_tests/pg_exclude.yml
+++ b/packaging_automation/tests/files/get_postgres_versions_tests/pg_exclude.yml
@@ -2,4 +2,4 @@ exclude:
   nightly:
     ol/7: [15]
   release:
-    all: [15]
+    all: []

--- a/packaging_automation/tests/files/get_postgres_versions_tests/pkgvars
+++ b/packaging_automation/tests/files/get_postgres_versions_tests/pkgvars
@@ -1,4 +1,4 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
-pkglatest=13.2
+pkglatest=13.2.0
 versioning=fancy

--- a/packaging_automation/tests/files/get_postgres_versions_tests/pkgvars
+++ b/packaging_automation/tests/files/get_postgres_versions_tests/pkgvars
@@ -1,4 +1,4 @@
 pkgname=citus
 pkgdesc='Citus (Open-Source)'
-pkglatest=11.0.5
+pkglatest=13.2
 versioning=fancy

--- a/packaging_automation/tests/files/get_postgres_versions_tests/postgres-matrix.yml
+++ b/packaging_automation/tests/files/get_postgres_versions_tests/postgres-matrix.yml
@@ -19,4 +19,12 @@ version_matrix:
   - 11.1:
       postgres_versions: [ 13, 14, 15 ]
   - 12.0:
-        postgres_versions: [ 14, 15 ]
+        postgres_versions: [ 14, 15]
+  - 12.1:
+        postgres_versions: [ 14, 15, 16 ]
+  - 13.0:
+        postgres_versions: [ 15, 16, 17 ]
+  - 13.1:
+        postgres_versions: [ 15, 16, 17 ]
+  - 13.2:
+        postgres_versions: [ 15, 16, 17 ]

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -153,8 +153,8 @@ def test_get_postgres_versions_ol_9():
         platform="ol/9",
     )
     # pg 15 is excluded for all releases with pg_exclude file
-    assert len(release_versions) == 2 and release_versions == ["14", "164"]
-    assert len(nightly_versions) == 3 and nightly_versions == ["14", "15", "16"]
+    assert len(release_versions) == 2 and release_versions == ["16", "17"]
+    assert len(nightly_versions) == 3 and nightly_versions == ["15", "16", "17"]
 
 
 def test_get_postgres_versions_el_9():
@@ -163,18 +163,18 @@ def test_get_postgres_versions_el_9():
         platform="el/9",
     )
     # pg 15 is excluded for all releases with pg_exclude file
-    assert len(release_versions) == 2 and release_versions == ["14", "16"]
-    assert len(nightly_versions) == 3 and nightly_versions == ["14", "15", "16"]
+    assert len(release_versions) == 2 and release_versions == ["16", "17"]
+    assert len(nightly_versions) == 3 and nightly_versions == ["15", "16", "17"]
 
 
-def test_get_postgres_versions_debain_bullseye():
+def test_get_postgres_versions_debian_bullseye():
     release_versions, nightly_versions = get_postgres_versions(
         input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
         platform="debian/bullseye",
     )
     # pg 15 is excluded for all releases with pg_exclude file
-    assert len(release_versions) == 2 and release_versions == ["14", "16"]
-    assert len(nightly_versions) == 3 and nightly_versions == ["14", "15", "16"]
+    assert len(release_versions) == 2 and release_versions == ["16", "17"]
+    assert len(nightly_versions) == 3 and nightly_versions == ["15", "16", "17"]
 
 
 def test_upload_to_package_cloud():

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -50,6 +50,7 @@ single_postgres_package_counts = {
     "debian/stretch": 2,
     "debian/bullseye": 2,
     "debian/bookworm": 2,
+    "debian/trixie": 2,
     "ubuntu/bionic": 2,
     "ubuntu/focal": 2,
     "ubuntu/jammy": 2,

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -38,24 +38,16 @@ PACKAGING_EXEC_FOLDER = f"{TEST_BASE_PATH}/{PACKAGING_SOURCE_FOLDER}"
 BASE_OUTPUT_FOLDER = f"{PACKAGING_EXEC_FOLDER}/packages"
 
 single_postgres_package_counts = {
-    "el/7": 2,
     "el/8": 3,
-    "ol/7": 2,
-    "ol/8": 3,
-    "almalinux/9": 3,
-    "almalinux/8": 3,
-    "rockylinux/9": 3,
     "el/9": 3,
+    "ol/8": 3,
     "ol/9": 3,
-    "debian/stretch": 2,
-    "debian/bullseye": 2,
-    "debian/bookworm": 2,
-    "debian/trixie": 2,
-    "ubuntu/bionic": 2,
-    "ubuntu/focal": 2,
-    "ubuntu/jammy": 2,
-    "ubuntu/kinetic": 2,
-    "ubuntu/noble": 2,
+    "debian/bullseye": 3,
+    "debian/bookworm": 3,
+    "debian/trixie": 3,
+    "ubuntu/focal": 3,
+    "ubuntu/jammy": 3,
+    "ubuntu/noble": 3,
 }
 
 TEST_GPG_KEY_NAME = "Citus Data <packaging@citusdata.com>"
@@ -137,8 +129,8 @@ def test_build_packages():
         )
         assert os.path.exists(postgres_version_file_path)
         config = dotenv_values(postgres_version_file_path)
-        assert config["release_versions"] == "12,13,14"
-        assert config["nightly_versions"] == "14,15"
+        assert config["release_versions"] == "14,15,16"
+        assert config["nightly_versions"] == "14,15,16"
 
 
 def test_get_required_package_count():
@@ -161,8 +153,8 @@ def test_get_postgres_versions_ol_9():
         platform="ol/9",
     )
     # pg 15 is excluded for all releases with pg_exclude file
-    assert len(release_versions) == 2 and release_versions == ["13", "14"]
-    assert len(nightly_versions) == 2 and nightly_versions == ["13", "14"]
+    assert len(release_versions) == 2 and release_versions == ["14", "164"]
+    assert len(nightly_versions) == 3 and nightly_versions == ["14", "15", "16"]
 
 
 def test_get_postgres_versions_el_9():
@@ -171,8 +163,8 @@ def test_get_postgres_versions_el_9():
         platform="el/9",
     )
     # pg 15 is excluded for all releases with pg_exclude file
-    assert len(release_versions) == 2 and release_versions == ["13", "14"]
-    assert len(nightly_versions) == 2 and nightly_versions == ["14", "15"]
+    assert len(release_versions) == 2 and release_versions == ["14", "16"]
+    assert len(nightly_versions) == 3 and nightly_versions == ["14", "15", "16"]
 
 
 def test_get_postgres_versions_debain_bullseye():
@@ -181,8 +173,8 @@ def test_get_postgres_versions_debain_bullseye():
         platform="debian/bullseye",
     )
     # pg 15 is excluded for all releases with pg_exclude file
-    assert len(release_versions) == 2 and release_versions == ["13", "14"]
-    assert len(nightly_versions) == 2 and nightly_versions == ["14", "15"]
+    assert len(release_versions) == 2 and release_versions == ["14", "16"]
+    assert len(nightly_versions) == 3 and nightly_versions == ["14", "15", "16"]
 
 
 def test_upload_to_package_cloud():

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -151,24 +151,24 @@ def test_get_required_package_count():
 
 
 def test_decode_os_packages():
-    os, release = decode_os_and_release("el/7")
-    assert os == "el" and release == "7"
+    os, release = decode_os_and_release("el/9")
+    assert os == "el" and release == "9"
 
 
-def test_get_postgres_versions_ol_7():
+def test_get_postgres_versions_ol_9():
     release_versions, nightly_versions = get_postgres_versions(
         input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
-        platform="ol/7",
+        platform="ol/9",
     )
     # pg 15 is excluded for all releases with pg_exclude file
     assert len(release_versions) == 2 and release_versions == ["13", "14"]
     assert len(nightly_versions) == 2 and nightly_versions == ["13", "14"]
 
 
-def test_get_postgres_versions_el_7():
+def test_get_postgres_versions_el_9():
     release_versions, nightly_versions = get_postgres_versions(
         input_files_dir=f"{os.getcwd()}/packaging_automation/tests/files/get_postgres_versions_tests",
-        platform="el/7",
+        platform="el/9",
     )
     # pg 15 is excluded for all releases with pg_exclude file
     assert len(release_versions) == 2 and release_versions == ["13", "14"]

--- a/packaging_automation/upload_to_package_cloud.py
+++ b/packaging_automation/upload_to_package_cloud.py
@@ -10,22 +10,17 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 supported_distros = {
-    "el/7": 140,
     "el/8": 205,
     "el/9": 240,
-    "ol/7": 146,
     "ol/8": 234,
     "ol/9": 244,
-    "debian/stretch": 149,
     "debian/buster": 150,
     "debian/bullseye": 207,
     "debian/bookworm": 215,
     "debian/trixie": 244, # needs to be validated
-    "ubuntu/bionic": 190,
     "ubuntu/focal": 210,
     "ubuntu/jammy": 237,
     "ubuntu/noble": 243, # needs to be validated
-    "ubuntu/kinetic": 261,
 }
 
 supported_repos = [

--- a/packaging_automation/upload_to_package_cloud.py
+++ b/packaging_automation/upload_to_package_cloud.py
@@ -20,9 +20,11 @@ supported_distros = {
     "debian/buster": 150,
     "debian/bullseye": 207,
     "debian/bookworm": 215,
+    "debian/trixie": 244, # needs to be validated
     "ubuntu/bionic": 190,
     "ubuntu/focal": 210,
     "ubuntu/jammy": 237,
+    "ubuntu/noble": 243, # needs to be validated
     "ubuntu/kinetic": 261,
 }
 


### PR DESCRIPTION
Added Trixie and Noble to supported list
Updated tests to run on supported versions of the used distros
Updated tests to run on latest Citus release (13.2)