### PR TITLE
Fix Docker templates: use explicit base image tags and update Alpine …

### DIFF
--- a/packaging_automation/templates/docker/alpine/alpine.tmpl.dockerfile
+++ b/packaging_automation/templates/docker/alpine/alpine.tmpl.dockerfile
@@ -12,30 +12,19 @@ LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.schema-version="1.0"
 
 # Build citus and delete all used libraries. Warning: Libraries installed in this section will be deleted after build completion
-RUN apk add --no-cache \
-            --virtual builddeps \
-        build-base \
-        krb5-dev \
-        curl \
-        curl-dev \
-        openssl-dev \
-        ca-certificates \
-        clang \
-        llvm \
-        lz4-dev \
-        zstd-dev \
-        libxslt-dev \
-        libxml2-dev \
-        icu-dev && \
-    apk add --no-cache libcurl && \
-    curl -sfLO "https://github.com/citusdata/citus/archive/v${VERSION}.tar.gz" && \
-    tar xzf "v${VERSION}.tar.gz" && \
-    cd "citus-${VERSION}" && \
-   ./configure --with-security-flags && \
-    make install && \
-    cd .. && \
-    rm -rf "citus-${VERSION}" "v${VERSION}.tar.gz" && \
-    apk del builddeps
+RUN apk add --no-cache --virtual builddeps \
+      build-base krb5-dev curl curl-dev openssl-dev ca-certificates \
+      llvm19-dev clang19 llvm19-libs \
+      lz4-dev zstd-dev libxslt-dev libxml2-dev icu-dev \
+ && apk add --no-cache libcurl \
+ && curl -sfLO "https://github.com/citusdata/citus/archive/v${VERSION}.tar.gz" \
+ && tar xzf "v${VERSION}.tar.gz" \
+ && cd "citus-${VERSION}" \
+ && ./configure --with-security-flags \
+ && make install \
+ && cd .. \
+ && rm -rf "citus-${VERSION}" "v${VERSION}.tar.gz" \
+ && apk del builddeps
 
 #--------End of Citus Build
 

--- a/packaging_automation/templates/docker/latest/latest.tmpl.dockerfile
+++ b/packaging_automation/templates/docker/latest/latest.tmpl.dockerfile
@@ -1,6 +1,6 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/latest/latest.tmpl.dockerfile.
-FROM postgres:{{postgres_version}}
+FROM postgres:{{postgres_version}}-bookworm
 ARG VERSION={{project_version}}
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \

--- a/packaging_automation/templates/docker/postgres-14/postgres-14.tmpl.dockerfile
+++ b/packaging_automation/templates/docker/postgres-14/postgres-14.tmpl.dockerfile
@@ -1,6 +1,6 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/postgres-14/postgres-14.tmpl.dockerfile.
-FROM postgres:{{postgres_version}}
+FROM postgres:{{postgres_version}}-bookworm
 ARG VERSION={{project_version}}
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \

--- a/packaging_automation/templates/docker/postgres-15/postgres-15.tmpl.dockerfile
+++ b/packaging_automation/templates/docker/postgres-15/postgres-15.tmpl.dockerfile
@@ -1,6 +1,6 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/postgres-15/postgres-15.tmpl.dockerfile.
-FROM postgres:{{postgres_version}}
+FROM postgres:{{postgres_version}}-bookworm
 ARG VERSION={{project_version}}
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \

--- a/packaging_automation/templates/docker/postgres-16/postgres-16.tmpl.dockerfile
+++ b/packaging_automation/templates/docker/postgres-16/postgres-16.tmpl.dockerfile
@@ -1,6 +1,6 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/postgres-16/postgres-16.tmpl.dockerfile.
-FROM postgres:{{postgres_version}}
+FROM postgres:{{postgres_version}}-bookworm
 ARG VERSION={{project_version}}
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \

--- a/packaging_automation/templates/docker/postgres-17/postgres-17.tmpl.dockerfile
+++ b/packaging_automation/templates/docker/postgres-17/postgres-17.tmpl.dockerfile
@@ -1,6 +1,6 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/postgres-17/postgres-17.tmpl.dockerfile.
-FROM postgres:{{postgres_version}}
+FROM postgres:{{postgres_version}}-bookworm
 ARG VERSION={{project_version}}
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \

--- a/packaging_automation/templates/docker/postgres-18/postgres-18.tmpl.dockerfile
+++ b/packaging_automation/templates/docker/postgres-18/postgres-18.tmpl.dockerfile
@@ -1,6 +1,6 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/postgres-18/postgres-18.tmpl.dockerfile.
-FROM postgres:{{postgres_version}}
+FROM postgres:{{postgres_version}}-bookworm
 ARG VERSION={{project_version}}
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \


### PR DESCRIPTION
Fix Docker templates: use explicit base image tags and update Alpine build

- Add -bookworm suffix to Debian-based Dockerfile templates to ensure
  consistent base images (postgres-14, postgres-15, postgres-16,
  postgres-17, postgres-18, latest)
- Update Alpine template to use versioned LLVM packages (llvm19-dev,
  clang19, llvm19-libs) instead of generic clang/llvm
- Refactor Alpine build commands for better readability

Backport from citusdata/docker@7794206