### PR TITLE
Use exported Citus requirements in test images

### DIFF
--- a/test-images/almalinux-9/Dockerfile
+++ b/test-images/almalinux-9/Dockerfile
@@ -42,18 +42,18 @@ USER root
 # Enable EPEL repository and install dependencies for Python 3.8
 RUN yum install -y epel-release && \
     yum install -y gcc make libcurl-devel openssl-devel bzip2-devel libffi-devel xz-devel wget tar zlib-devel && \
-    wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz && \
-    tar xvf Python-3.8.12.tgz && \
-    cd Python-3.8.12 && \
+    wget https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz && \
+    tar xvf Python-3.12.12.tgz && \
+    cd Python-3.12.12 && \
     ./configure --enable-optimizations && \
     make altinstall && \
-    python3.8 -m pip install pip-tools
+    python3.12 -m pip install pip-tools
 
 
 COPY scripts/* ./
 
 # Use pip-tools to compile and install requirements
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 

--- a/test-images/centos-7/Dockerfile
+++ b/test-images/centos-7/Dockerfile
@@ -42,7 +42,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN yum install -y gcc make && \
     yum -y install  libcurl-devel \
                     openssl-devel \
@@ -51,16 +51,16 @@ RUN yum install -y gcc make && \
                     xz-devel \
                     python38-devel \
                     openssl-devel &&\
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 
 USER postgres

--- a/test-images/centos-8/Dockerfile
+++ b/test-images/centos-8/Dockerfile
@@ -44,7 +44,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN yum install -y gcc make && \
     yum -y install  libcurl-devel \
                     openssl-devel \
@@ -53,16 +53,16 @@ RUN yum install -y gcc make && \
                     xz-devel \
                     python38-devel \
                     openssl-devel &&\
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 
 USER postgres

--- a/test-images/debian-bookworm/Dockerfile
+++ b/test-images/debian-bookworm/Dockerfile
@@ -51,7 +51,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN apt-get install -y  build-essential \
                     libcurl4-openssl-dev \
                     libssl-dev \
@@ -59,16 +59,16 @@ RUN apt-get install -y  build-essential \
                     curl \
                     libffi-dev \
                     gnupg2 && \
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 

--- a/test-images/debian-bullseye/Dockerfile
+++ b/test-images/debian-bullseye/Dockerfile
@@ -51,7 +51,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN apt-get install -y  build-essential \
                     libcurl4-openssl-dev \
                     libssl-dev \
@@ -59,16 +59,16 @@ RUN apt-get install -y  build-essential \
                     curl \
                     libffi-dev \
                     gnupg2 && \
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 

--- a/test-images/debian-buster/Dockerfile
+++ b/test-images/debian-buster/Dockerfile
@@ -52,7 +52,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN apt-get install -y  build-essential \
                     libcurl4-openssl-dev \
                     libssl-dev \
@@ -60,16 +60,16 @@ RUN apt-get install -y  build-essential \
                     curl \
                     libffi-dev \
                     gnupg2 && \
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 

--- a/test-images/debian-stretch/Dockerfile
+++ b/test-images/debian-stretch/Dockerfile
@@ -52,7 +52,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN apt-get install -y  build-essential \
                     libcurl4-openssl-dev \
                     libssl-dev \
@@ -60,16 +60,16 @@ RUN apt-get install -y  build-essential \
                     curl \
                     libffi-dev \
                     gnupg2 && \
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 

--- a/test-images/debian-trixie/Dockerfile
+++ b/test-images/debian-trixie/Dockerfile
@@ -52,7 +52,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN apt-get install -y  build-essential \
                     libcurl4-openssl-dev \
                     libssl-dev \
@@ -60,16 +60,16 @@ RUN apt-get install -y  build-essential \
                     curl \
                     libffi-dev \
                     gnupg2 && \
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 

--- a/test-images/el-7/Dockerfile
+++ b/test-images/el-7/Dockerfile
@@ -42,7 +42,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN yum install -y gcc make && \
     yum groupinstall -y 'Development Tools' && \
     yum -y install  libcurl-devel \
@@ -52,16 +52,16 @@ RUN yum install -y gcc make && \
                     xz-devel \
                     python38-devel \
                     openssl-devel &&\
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 
 USER postgres

--- a/test-images/el-8/Dockerfile
+++ b/test-images/el-8/Dockerfile
@@ -42,7 +42,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN yum install -y gcc make && \
     yum -y install  libcurl-devel \
                     openssl-devel \
@@ -51,16 +51,16 @@ RUN yum install -y gcc make && \
                     xz-devel \
                     python38-devel \
                     openssl-devel &&\
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 
 USER postgres

--- a/test-images/ol-7/Dockerfile
+++ b/test-images/ol-7/Dockerfile
@@ -35,7 +35,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN yum install -y gcc make && \
     yum -y install  libcurl-devel \
                     openssl-devel \
@@ -45,16 +45,16 @@ RUN yum install -y gcc make && \
                     python38-devel \
                     libzstd-devel \
                     openssl-devel &&\
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 
 USER postgres

--- a/test-images/ol-9/Dockerfile
+++ b/test-images/ol-9/Dockerfile
@@ -35,7 +35,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN yum install -y gcc make && \
     yum -y install libcurl-devel \
                     openssl-devel \
@@ -44,16 +44,16 @@ RUN yum install -y gcc make && \
                     xz-devel \
                     libzstd-devel \
                     zlib-devel &&\
-    curl https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-    tar xvf Python-3.8.12.tgz &&\
-    cd Python-3.8.*/ && \
+    curl https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+    tar xvf Python-3.12.12.tgz &&\
+    cd Python-3.12.*/ && \
     ./configure --enable-optimizations && \
     make altinstall && \
-    python3.8 -m pip install pip-tools
+    python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 
 USER postgres

--- a/test-images/scripts/requirements.in
+++ b/test-images/scripts/requirements.in
@@ -1,16 +1,60 @@
-docker
-GitPython
-Jinja2
-parameters_validation
-pathlib2
-pycurl<7.45.0
-PyGithub
-pytest
-python-gnupg
-python-string-utils
-PyYAML
-requests
-SQLAlchemy
-urllib3
-wheel
-python-dotenv
+-i https://pypi.python.org/simple
+aioquic==1.2.0; python_version >= '3.8'
+argon2-cffi==25.1.0; python_version >= '3.8'
+argon2-cffi-bindings==25.1.0; python_version >= '3.9'
+asgiref==3.11.0; python_version >= '3.9'
+attrs==26.1.0; python_version >= '3.9'
+bcrypt==5.0.0; python_version >= '3.8'
+blinker==1.9.0; python_version >= '3.9'
+brotli==1.2.0
+certifi==2026.2.25; python_version >= '3.7'
+cffi==2.0.0; python_version >= '3.9'
+click==8.3.2; python_version >= '3.10'
+construct==2.10.70; python_version >= '3.6'
+cryptography==46.0.7; python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'
+docopt==0.6.2
+execnet==2.1.2; python_version >= '3.8'
+filelock==3.28.0; python_version >= '3.10'
+flask==3.1.3; python_version >= '3.9'
+h11==0.16.0; python_version >= '3.8'
+h2==4.3.0; python_version >= '3.9'
+hpack==4.1.0; python_version >= '3.9'
+hyperframe==6.1.0; python_version >= '3.9'
+iniconfig==2.3.0; python_version >= '3.10'
+itsdangerous==2.2.0; python_version >= '3.8'
+jinja2==3.1.6; python_version >= '3.7'
+kaitaistruct==0.11; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+ldap3==2.9.1
+markupsafe==3.0.3; python_version >= '3.9'
+mitmproxy==12.2.2; python_version >= '3.12'
+mitmproxy-linux==0.12.9; python_version >= '3.12'
+mitmproxy-rs==0.12.9; python_version >= '3.12'
+msgpack==1.1.2; python_version >= '3.9'
+packaging==26.1; python_version >= '3.8'
+pluggy==1.6.0; python_version >= '3.9'
+psycopg==3.3.3; python_version >= '3.10'
+publicsuffix2==2.20191221
+pyasn1==0.6.3; python_version >= '3.8'
+pyasn1-modules==0.4.2; python_version >= '3.8'
+pycparser==3.0; python_version >= '3.10'
+pygments==2.20.0; python_version >= '3.9'
+pylsqpack==0.3.24; python_version >= '3.10'
+pyopenssl==25.3.0; python_version >= '3.7'
+pyparsing==3.3.2; python_version >= '3.9'
+pyperclip==1.9.0
+pytest==9.0.3; python_version >= '3.10'
+pytest-asyncio==1.3.0; python_version >= '3.10'
+pytest-repeat==0.9.4; python_version >= '3.9'
+pytest-timeout==2.4.0; python_version >= '3.7'
+pytest-xdist==3.8.0; python_version >= '3.9'
+pyyaml==6.0.3; python_version >= '3.8'
+ruamel.yaml==0.19.1; python_version >= '3.9'
+service-identity==24.2.0; python_version >= '3.8'
+sortedcontainers==2.4.0
+tornado==6.5.5; python_version >= '3.9'
+typing-extensions==4.14.0; python_version >= '3.9'
+urwid==3.0.5; python_full_version >= '3.9.0'
+wcwidth==0.6.0; python_version >= '3.8'
+werkzeug==3.1.6; python_version >= '3.9'
+wsproto==1.3.2; python_version >= '3.10'
+zstandard==0.25.0; python_version >= '3.9'

--- a/test-images/scripts/test_internal.sh
+++ b/test-images/scripts/test_internal.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python3.8 -m pytest -q test.py -s
+python3.12 -m pytest -q test.py -s

--- a/test-images/ubuntu-bionic/Dockerfile
+++ b/test-images/ubuntu-bionic/Dockerfile
@@ -52,7 +52,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN apt-get install -y  build-essential \
                     libcurl4-openssl-dev \
                     libssl-dev \
@@ -60,16 +60,16 @@ RUN apt-get install -y  build-essential \
                     curl \
                     libffi-dev \
                     gnupg2 && \
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 

--- a/test-images/ubuntu-focal/Dockerfile
+++ b/test-images/ubuntu-focal/Dockerfile
@@ -52,7 +52,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN apt-get install -y  build-essential \
                     libcurl4-openssl-dev \
                     libssl-dev \
@@ -60,16 +60,16 @@ RUN apt-get install -y  build-essential \
                     curl \
                     libffi-dev \
                     gnupg2 && \
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 

--- a/test-images/ubuntu-jammy/Dockerfile
+++ b/test-images/ubuntu-jammy/Dockerfile
@@ -52,7 +52,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN apt-get install -y  build-essential \
                     libcurl4-openssl-dev \
                     libssl-dev \
@@ -60,16 +60,16 @@ RUN apt-get install -y  build-essential \
                     curl \
                     libffi-dev \
                     gnupg2 && \
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 

--- a/test-images/ubuntu-noble/Dockerfile
+++ b/test-images/ubuntu-noble/Dockerfile
@@ -52,7 +52,7 @@ USER postgres
 RUN cd ~ && initdb -D citus && echo "shared_preload_libraries = 'citus'" >> citus/postgresql.conf
 
 USER root
-# Install python 3.8 and its dependencies
+# Install python 3.12 and its dependencies
 RUN apt-get install -y  build-essential \
                     libcurl4-openssl-dev \
                     libssl-dev \
@@ -60,16 +60,16 @@ RUN apt-get install -y  build-essential \
                     curl \
                     libffi-dev \
                     gnupg2 && \
-      curl  https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz --output Python-3.8.12.tgz &&\
-      tar xvf Python-3.8.12.tgz &&\
-      cd Python-3.8.*/ && \
+      curl  https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz --output Python-3.12.12.tgz &&\
+      tar xvf Python-3.12.12.tgz &&\
+      cd Python-3.12.*/ && \
       ./configure --enable-optimizations && \
        make altinstall && \
-       python3.8 -m pip install pip-tools
+       python3.12 -m pip install pip-tools
 
 COPY scripts/* ./
 
-RUN pip-compile && python3.8 -m pip install -r requirements.txt
+RUN pip-compile && python3.12 -m pip install -r requirements.txt
 
 USER postgres
 


### PR DESCRIPTION
## Summary
- replace the shared test-image Python dependency input with the exported requirements from the Citus failure-test environment
- move the test-image Python runtime from 3.8 to 3.12 so upstream mitmproxy 12.2.2 can be installed
- keep the image test runner aligned with the refreshed dependency set

## Context
This supports the Citus dependency refresh and the switch away from the forked mitmproxy reference in the test environment.

## Verification
- installed the shared test-image requirements in a clean Python 3.12 environment
- confirmed the resolved versions include mitmproxy 12.2.2, cryptography 46.0.7, pytest 9.0.3, Werkzeug 3.1.6, and tornado 6.5.5