### PR TITLE
Phase 1: use GitHub App token in tools test workflows

### DIFF
--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -1,8 +1,6 @@
 name: Citus package all platforms tests
 
 env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
   MICROSOFT_EMAIL: gindibay@microsoft.com
   USER_NAME: Gurkan Indibay
@@ -36,6 +34,19 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/packaging-methods-tests.yml
+++ b/.github/workflows/packaging-methods-tests.yml
@@ -16,7 +16,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/packaging-methods-tests.yml
+++ b/.github/workflows/packaging-methods-tests.yml
@@ -1,8 +1,5 @@
 name: Packaging helper methods tests
 
-env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
 on:
   push:
     branches:
@@ -15,6 +12,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/statistic-schedule.yml
+++ b/.github/workflows/statistic-schedule.yml
@@ -5,7 +5,6 @@ env:
   DB_PASSWORD: ${{ secrets.STATS_DB_PASSWORD }}
   DB_HOST_AND_PORT: ${{ secrets.STATS_DB_HOST_AND_PORT }}
   DB_NAME: ${{ secrets.STATS_DB_NAME }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 on:
   schedule:
     - cron: "0 16 * * *"
@@ -25,6 +24,17 @@ jobs:
         job_name: [docker_pull_citus, github_clone_citus, homebrew_citus]
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/statistic-schedule.yml
+++ b/.github/workflows/statistic-schedule.yml
@@ -28,7 +28,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/statistic-tests.yml
+++ b/.github/workflows/statistic-tests.yml
@@ -5,7 +5,6 @@ env:
   DB_PASSWORD: ${{ secrets.STATS_DB_PASSWORD }}
   DB_HOST_AND_PORT: ${{ secrets.STATS_DB_HOST_AND_PORT }}
   DB_NAME: ${{ secrets.STATS_DB_NAME }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
   PACKAGE_CLOUD_ADMIN_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_ADMIN_API_TOKEN }}
 on:
@@ -21,6 +20,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/statistic-tests.yml
+++ b/.github/workflows/statistic-tests.yml
@@ -24,7 +24,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -1,7 +1,6 @@
 name: Tool Tests
 
 env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   MICROSOFT_EMAIL: gindibay@microsoft.com
   USER_NAME: Gurkan Indibay
   MAIN_BRANCH: all-citus
@@ -27,6 +26,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -30,7 +30,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 


### PR DESCRIPTION
## Phase 1 of the GH_TOKEN -> GitHub App migration

Migrates the five **tools test workflows** from the org PAT secrets.GH_TOKEN to a per-job
**GitHub App installation token**:

- `tool-tests.yml`
- `packaging-methods-tests.yml`
- `statistic-tests.yml`
- `statistic-schedule.yml`
- `citus-package-all-platforms-test.yml`

### What changed
Each consuming job now mints a token with `actions/create-github-app-token@v2` (using the existing
org secrets `GH_APP_ID` / `GH_APP_KEY`, `owner: citusdata`) and exports it to `\`
as `GH_TOKEN` (plus `GITHUB_TOKEN` for the all-platforms test). The `GH_TOKEN` entries are
removed from the top-level `env:` blocks, because top-level/job `env` cannot reference the
`steps` context.

### Why this is safe / zero-downtime
- An installation token is a drop-in replacement for the PAT (token-type-agnostic): no `tools`
  package or script changes, no re-tag.
- `secrets.GH_TOKEN` is intentionally left defined org-wide so other (not-yet-migrated) workflows
  and build branches keep working during the staged migration.
- Lowest-risk first slice: these are PR/schedule-triggered test workflows with no release publishing.

### Validation
First CI run on this PR also validates that `GH_APP_ID` / `GH_APP_KEY` are visible to the
`tools` repo and that token minting works.