### PR TITLE
Fix pre-existing test failures: align docker PG versions to source pkgvars; retarget EOL build images

### DIFF
--- a/packaging_automation/tests/test_citus_package_utils.py
+++ b/packaging_automation/tests/test_citus_package_utils.py
@@ -142,7 +142,7 @@ def test_get_postgres_versions():
 def test_build_package_debian():
     input_output_parameters = InputOutputParameters.build(
         PACKAGING_EXEC_FOLDER,
-        f"{OUTPUT_FOLDER}/debian-stretch",
+        f"{OUTPUT_FOLDER}/debian-bookworm",
         output_validation=False,
     )
 
@@ -156,7 +156,7 @@ def test_build_package_debian():
     build_package(
         github_token=GH_TOKEN,
         build_type=BuildType.release,
-        docker_platform="debian-stretch",
+        docker_platform="debian-bookworm",
         postgres_version="all",
         input_output_parameters=input_output_parameters,
         is_test=True,
@@ -205,7 +205,7 @@ def test_sign_packages():
         input_output_parameters=input_output_parameters,
     )
     sign_packages(
-        sub_folder="debian-stretch",
+        sub_folder="debian-bookworm",
         signing_credentials=signing_credentials,
         input_output_parameters=input_output_parameters,
     )

--- a/packaging_automation/tests/test_update_docker.py
+++ b/packaging_automation/tests/test_update_docker.py
@@ -14,8 +14,9 @@ from ..update_docker import (
     update_docker_file_for_latest_postgres,
     update_regular_docker_compose_file,
     update_docker_file_alpine,
-    update_docker_file_for_postgres15,
-    update_docker_file_for_postgres14,
+    update_docker_file_for_postgres16,
+    update_docker_file_for_postgres17,
+    update_docker_file_for_postgres18,
     update_changelog,
 )
 
@@ -23,8 +24,9 @@ BASE_PATH = os.getenv("BASE_PATH", default=pathlib2.Path(__file__).parents[2])
 TEST_BASE_PATH = f"{BASE_PATH}/docker"
 PROJECT_VERSION = "12.0.0"
 
-POSTGRES_15_VERSION = "15.4"
-POSTGRES_14_VERSION = "14.9"
+POSTGRES_18_VERSION = "18.1"
+POSTGRES_17_VERSION = "17.6"
+POSTGRES_16_VERSION = "16.10"
 
 PROJECT_NAME = "citus"
 version_details = get_version_details(PROJECT_VERSION)
@@ -45,7 +47,7 @@ def teardown_module():
 
 def test_update_docker_file_for_latest_postgres():
     update_docker_file_for_latest_postgres(
-        PROJECT_VERSION, TEMPLATE_PATH, TEST_BASE_PATH, POSTGRES_14_VERSION
+        PROJECT_VERSION, TEMPLATE_PATH, TEST_BASE_PATH, POSTGRES_18_VERSION
     )
     with open(
         f"{TEST_BASE_PATH}/Dockerfile",
@@ -55,7 +57,7 @@ def test_update_docker_file_for_latest_postgres():
     ) as reader:
         content = reader.read()
         lines = content.splitlines()
-        assert lines[2].strip() == f"FROM postgres:{POSTGRES_14_VERSION}"
+        assert lines[2].strip() == f"FROM postgres:{POSTGRES_18_VERSION}"
         assert lines[3].strip() == f"ARG VERSION={PROJECT_VERSION}"
         assert (
             f"postgresql-$PG_MAJOR-{PROJECT_NAME}-"
@@ -83,7 +85,7 @@ def test_update_regular_docker_compose_file():
 
 def test_update_docker_file_alpine():
     update_docker_file_alpine(
-        PROJECT_VERSION, TEMPLATE_PATH, TEST_BASE_PATH, POSTGRES_14_VERSION
+        PROJECT_VERSION, TEMPLATE_PATH, TEST_BASE_PATH, POSTGRES_18_VERSION
     )
     with open(
         f"{TEST_BASE_PATH}/alpine/Dockerfile",
@@ -93,24 +95,24 @@ def test_update_docker_file_alpine():
     ) as reader:
         content = reader.read()
         lines = content.splitlines()
-        assert lines[2].strip() == f"FROM postgres:{POSTGRES_14_VERSION}-alpine"
+        assert lines[2].strip() == f"FROM postgres:{POSTGRES_18_VERSION}-alpine"
         assert lines[3].strip() == f"ARG VERSION={PROJECT_VERSION}"
         assert len(lines) == 58
 
 
-def test_update_docker_file_for_postgres14():
-    update_docker_file_for_postgres14(
-        PROJECT_VERSION, TEMPLATE_PATH, TEST_BASE_PATH, POSTGRES_14_VERSION
+def test_update_docker_file_for_postgres16():
+    update_docker_file_for_postgres16(
+        PROJECT_VERSION, TEMPLATE_PATH, TEST_BASE_PATH, POSTGRES_16_VERSION
     )
     with open(
-        f"{TEST_BASE_PATH}/postgres-14/Dockerfile",
+        f"{TEST_BASE_PATH}/postgres-16/Dockerfile",
         "r",
         encoding=DEFAULT_ENCODING_FOR_FILE_HANDLING,
         errors=DEFAULT_UNICODE_ERROR_HANDLER,
     ) as reader:
         content = reader.read()
         lines = content.splitlines()
-        assert lines[2].strip() == f"FROM postgres:{POSTGRES_14_VERSION}"
+        assert lines[2].strip() == f"FROM postgres:{POSTGRES_16_VERSION}"
         assert lines[3].strip() == f"ARG VERSION={PROJECT_VERSION}"
         assert (
             f"postgresql-$PG_MAJOR-{PROJECT_NAME}-"
@@ -120,19 +122,41 @@ def test_update_docker_file_for_postgres14():
         assert len(lines) == 42
 
 
-def test_update_docker_file_for_postgres15():
-    update_docker_file_for_postgres15(
-        PROJECT_VERSION, TEMPLATE_PATH, TEST_BASE_PATH, POSTGRES_15_VERSION
+def test_update_docker_file_for_postgres17():
+    update_docker_file_for_postgres17(
+        PROJECT_VERSION, TEMPLATE_PATH, TEST_BASE_PATH, POSTGRES_17_VERSION
     )
     with open(
-        f"{TEST_BASE_PATH}/postgres-15/Dockerfile",
+        f"{TEST_BASE_PATH}/postgres-17/Dockerfile",
         "r",
         encoding=DEFAULT_ENCODING_FOR_FILE_HANDLING,
         errors=DEFAULT_UNICODE_ERROR_HANDLER,
     ) as reader:
         content = reader.read()
         lines = content.splitlines()
-        assert lines[2].strip() == f"FROM postgres:{POSTGRES_15_VERSION}"
+        assert lines[2].strip() == f"FROM postgres:{POSTGRES_17_VERSION}"
+        assert lines[3].strip() == f"ARG VERSION={PROJECT_VERSION}"
+        assert (
+            f"postgresql-$PG_MAJOR-{PROJECT_NAME}-"
+            f"{version_details['major']}.{version_details['minor']}=$CITUS_VERSION"
+            in lines[21]
+        )
+        assert len(lines) == 42
+
+
+def test_update_docker_file_for_postgres18():
+    update_docker_file_for_postgres18(
+        PROJECT_VERSION, TEMPLATE_PATH, TEST_BASE_PATH, POSTGRES_18_VERSION
+    )
+    with open(
+        f"{TEST_BASE_PATH}/postgres-18/Dockerfile",
+        "r",
+        encoding=DEFAULT_ENCODING_FOR_FILE_HANDLING,
+        errors=DEFAULT_UNICODE_ERROR_HANDLER,
+    ) as reader:
+        content = reader.read()
+        lines = content.splitlines()
+        assert lines[2].strip() == f"FROM postgres:{POSTGRES_18_VERSION}"
         assert lines[3].strip() == f"ARG VERSION={PROJECT_VERSION}"
         assert (
             f"postgresql-$PG_MAJOR-{PROJECT_NAME}-"
@@ -177,5 +201,6 @@ def test_update_changelog_without_postgres():
 
 def test_pkgvar_postgres_version_existence():
     config = dotenv_values(PKGVARS_FILE)
-    assert config["postgres_15_version"]
-    assert config["postgres_14_version"]
+    assert config["postgres_16_version"]
+    assert config["postgres_17_version"]
+    assert config["postgres_18_version"]

--- a/packaging_automation/update_docker.py
+++ b/packaging_automation/update_docker.py
@@ -29,19 +29,15 @@ class SupportedDockerImages(Enum):
     latest = 1
     docker_compose = 2
     alpine = 3
-    postgres14 = 4
-    postgres15 = 5
-    postgres16 = 6
-    postgres17 = 7
-    postgres18 = 8
+    postgres16 = 4
+    postgres17 = 5
+    postgres18 = 6
 
 
 docker_templates = {
     SupportedDockerImages.latest: "latest/latest.tmpl.dockerfile",
     SupportedDockerImages.docker_compose: "latest/docker-compose.tmpl.yml",
     SupportedDockerImages.alpine: "alpine/alpine.tmpl.dockerfile",
-    SupportedDockerImages.postgres14: "postgres-14/postgres-14.tmpl.dockerfile",
-    SupportedDockerImages.postgres15: "postgres-15/postgres-15.tmpl.dockerfile",
     SupportedDockerImages.postgres16: "postgres-16/postgres-16.tmpl.dockerfile",
     SupportedDockerImages.postgres17: "postgres-17/postgres-17.tmpl.dockerfile",
     SupportedDockerImages.postgres18: "postgres-18/postgres-18.tmpl.dockerfile",
@@ -51,8 +47,6 @@ docker_outputs = {
     SupportedDockerImages.latest: "Dockerfile",
     SupportedDockerImages.docker_compose: "docker-compose.yml",
     SupportedDockerImages.alpine: "alpine/Dockerfile",
-    SupportedDockerImages.postgres14: "postgres-14/Dockerfile",
-    SupportedDockerImages.postgres15: "postgres-15/Dockerfile",
     SupportedDockerImages.postgres16: "postgres-16/Dockerfile",
     SupportedDockerImages.postgres17: "postgres-17/Dockerfile",
     SupportedDockerImages.postgres18: "postgres-18/Dockerfile",
@@ -159,40 +153,6 @@ def update_docker_file_for_postgres16(
     write_to_file(content, dest_file_name)
 
 
-def update_docker_file_for_postgres15(
-    project_version: str, template_path: str, exec_path: str, postgres_version: str
-):
-    minor_version = get_minor_project_version_for_docker(project_version)
-    debian_project_version = project_version.replace("_", "-")
-    content = process_template_file_with_minor(
-        debian_project_version,
-        template_path,
-        docker_templates[SupportedDockerImages.postgres15],
-        minor_version,
-        postgres_version,
-    )
-    dest_file_name = f"{exec_path}/{docker_outputs[SupportedDockerImages.postgres15]}"
-    create_directory_if_not_exists(dest_file_name)
-    write_to_file(content, dest_file_name)
-
-
-def update_docker_file_for_postgres14(
-    project_version: str, template_path: str, exec_path: str, postgres_version: str
-):
-    minor_version = get_minor_project_version_for_docker(project_version)
-    debian_project_version = project_version.replace("_", "-")
-    content = process_template_file_with_minor(
-        debian_project_version,
-        template_path,
-        docker_templates[SupportedDockerImages.postgres14],
-        minor_version,
-        postgres_version,
-    )
-    dest_file_name = f"{exec_path}/{docker_outputs[SupportedDockerImages.postgres14]}"
-    create_directory_if_not_exists(dest_file_name)
-    write_to_file(content, dest_file_name)
-
-
 def create_directory_if_not_exists(dest_file_name):
     dir_name = os.path.dirname(dest_file_name)
     if not os.path.exists(dir_name):
@@ -237,8 +197,6 @@ def update_all_docker_files(project_version: str, exec_path: str):
         postgres_18_version,
         postgres_17_version,
         postgres_16_version,
-        postgres_15_version,
-        postgres_14_version,
     ) = read_postgres_versions(pkgvars_file)
 
     latest_postgres_version = postgres_18_version
@@ -249,12 +207,6 @@ def update_all_docker_files(project_version: str, exec_path: str):
     update_regular_docker_compose_file(project_version, template_path, exec_path)
     update_docker_file_alpine(
         project_version, template_path, exec_path, latest_postgres_version
-    )
-    update_docker_file_for_postgres14(
-        project_version, template_path, exec_path, postgres_14_version
-    )
-    update_docker_file_for_postgres15(
-        project_version, template_path, exec_path, postgres_15_version
     )
     update_docker_file_for_postgres16(
         project_version, template_path, exec_path, postgres_16_version
@@ -274,8 +226,6 @@ def read_postgres_versions(pkgvars_file: str) -> Tuple[str, str, str]:
         config["postgres_18_version"],
         config["postgres_17_version"],
         config["postgres_16_version"],
-        config["postgres_15_version"],
-        config["postgres_14_version"],
     )
 
 


### PR DESCRIPTION
## Summary

Fixes two pre-existing, token-independent failures in the `packaging_automation` test suite. **This is INDEPENDENT of the GH_TOKEN→GitHub App migration happening elsewhere** — no `.github/workflows/*` files and no GH_TOKEN/app-token code were touched. Scope is strictly the Python tests + the production code they exercise.

## Root causes & fixes

### Failure #1 — docker `pkgvars` schema drift (PG14/15 removed upstream)
`test_update_docker.py::test_pkgvar_postgres_version_existence` failed with `KeyError: 'postgres_15_version'`.

citusdata/docker's `pkgvars` is the **source of truth** and now ships only `postgres_16/17/18` (16.10 / 17.6 / 18.1); `postgres_14_version` and `postgres_15_version` were removed upstream. This was **not just a test bug** — production `update_docker.py` was also out of sync:
- `read_postgres_versions()` returned `config['postgres_14_version']` / `['postgres_15_version']` → would `KeyError` at runtime against the current pkgvars.
- `update_all_docker_files()` unpacked 5 values and called `update_docker_file_for_postgres14(...)` / `..._postgres15(...)`.

**Changes (`update_docker.py`):** aligned automation to PG16/17/18 — trimmed the `SupportedDockerImages` enum and the `docker_templates` / `docker_outputs` dicts; removed the now-dead `update_docker_file_for_postgres14` / `_postgres15` helpers and their invocations; updated `read_postgres_versions()` and `update_all_docker_files()` to 18/17/16. Confirmed via repo-wide grep that nothing else imports/calls the removed pieces.

**Changes (`test_update_docker.py`):** swapped imports to `update_docker_file_for_postgres16/17/18`; updated constants to `POSTGRES_16/17/18_VERSION` (16.10/17.6/18.1, read from the current docker pkgvars); retargeted/renamed the per-version tests and the `test_pkgvar_postgres_version_existence` assertions to 16/17/18.

### Failure #2 — EOL / unavailable Docker build images
`test_citus_package_utils.py::test_build_package_debian` targeted `debian-stretch` (long EOL; archived apt repos make the build fail). Retargeted to **`debian-bookworm`** (confirmed-available `citus/packaging-test:debian-bookworm-all`), and updated `test_sign_packages`' `sub_folder` consistently so the suite stays coherent.

`test_build_package_rpm` targets `almalinux-9-pg17` → `citus/packaging-test:almalinux-9-pg17`. That tag exists and builds successfully; the earlier failure was transient (Docker-unavailable), so it is **kept unchanged**.

## Validation (local: WSL + Docker Desktop)
- `test_update_docker.py`: **9 passed**.
- `prospector`: **0 messages**; `black --check`: **clean**.
- `test_build_package_rpm` (almalinux-9-pg17): **1 passed** (~62s).
- `test_build_package_debian` (debian-bookworm): deb build completes **green** — `dh_installdocs` OK, `.deb` artifacts built for postgresql-15/16/17-citus, lintian clean, build exit 0 — when run on a native-Linux filesystem (verified via a permission-correct Docker volume populated with `git archive`, which preserves git's 0644/0755 modes).

### Note for maintainers / CI
The `test_build_package_debian` pytest cannot pass when run directly from a Windows-hosted `/mnt/c` mount: DrvFs reports every file as `0777`, so debhelper's "executable config files" feature treats `debian/docs` as an executable script and `dh_installdocs` fails. Git records `debian/docs` as `100644`, so on CI's native Linux filesystem this passes — and the underlying build is proven green locally via the perms-correct volume. **Please confirm `test_build_package_debian` (bookworm) via CI.**

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>