### PR TITLE
Tools GH App token migration (phase 1) + per-pg build_packages filter

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -40,7 +40,7 @@ jobs:
 
       # This step is to fetch the images unanonymously to have higher bandwidth
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -33,14 +33,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           path: tools
 
       # This step is to fetch the images unanonymously to have higher bandwidth
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -1,8 +1,6 @@
 name: Citus package all platforms tests
 
 env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
   MICROSOFT_EMAIL: gindibay@microsoft.com
   USER_NAME: Gurkan Indibay
@@ -36,6 +34,19 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}

--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -48,7 +48,7 @@ jobs:
           echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/citus-package-all-platforms-test.yml
+++ b/.github/workflows/citus-package-all-platforms-test.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,16 +25,16 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/delete-packagecloud-packages.yml
+++ b/.github/workflows/delete-packagecloud-packages.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/package-cloud-download-schedule.yml
+++ b/.github/workflows/package-cloud-download-schedule.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -19,7 +19,7 @@ jobs:
       citus_version: ${{ steps.get-citus-version.outputs.citus_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
       - name: Package version
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/packaging-methods-tests.yml
+++ b/.github/workflows/packaging-methods-tests.yml
@@ -16,7 +16,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/packaging-methods-tests.yml
+++ b/.github/workflows/packaging-methods-tests.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}

--- a/.github/workflows/packaging-methods-tests.yml
+++ b/.github/workflows/packaging-methods-tests.yml
@@ -1,8 +1,5 @@
 name: Packaging helper methods tests
 
-env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
 on:
   push:
     branches:
@@ -15,6 +12,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/packaging-methods-tests.yml
+++ b/.github/workflows/packaging-methods-tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/packaging-methods-tests.yml
+++ b/.github/workflows/packaging-methods-tests.yml
@@ -16,7 +16,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/publish-docker-image-tests.yml
+++ b/.github/workflows/publish-docker-image-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/pypi-statistics-schedule.yml
+++ b/.github/workflows/pypi-statistics-schedule.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/statistic-schedule.yml
+++ b/.github/workflows/statistic-schedule.yml
@@ -5,7 +5,6 @@ env:
   DB_PASSWORD: ${{ secrets.STATS_DB_PASSWORD }}
   DB_HOST_AND_PORT: ${{ secrets.STATS_DB_HOST_AND_PORT }}
   DB_NAME: ${{ secrets.STATS_DB_NAME }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 on:
   schedule:
     - cron: "0 16 * * *"
@@ -25,6 +24,17 @@ jobs:
         job_name: [docker_pull_citus, github_clone_citus, homebrew_citus]
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/statistic-schedule.yml
+++ b/.github/workflows/statistic-schedule.yml
@@ -28,7 +28,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/statistic-schedule.yml
+++ b/.github/workflows/statistic-schedule.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/statistic-schedule.yml
+++ b/.github/workflows/statistic-schedule.yml
@@ -28,7 +28,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/statistic-schedule.yml
+++ b/.github/workflows/statistic-schedule.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}

--- a/.github/workflows/statistic-tests.yml
+++ b/.github/workflows/statistic-tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/statistic-tests.yml
+++ b/.github/workflows/statistic-tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}

--- a/.github/workflows/statistic-tests.yml
+++ b/.github/workflows/statistic-tests.yml
@@ -5,7 +5,6 @@ env:
   DB_PASSWORD: ${{ secrets.STATS_DB_PASSWORD }}
   DB_HOST_AND_PORT: ${{ secrets.STATS_DB_HOST_AND_PORT }}
   DB_NAME: ${{ secrets.STATS_DB_NAME }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   PACKAGE_CLOUD_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
   PACKAGE_CLOUD_ADMIN_API_TOKEN: ${{ secrets.PACKAGE_CLOUD_ADMIN_API_TOKEN }}
 on:
@@ -21,6 +20,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/statistic-tests.yml
+++ b/.github/workflows/statistic-tests.yml
@@ -24,7 +24,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/statistic-tests.yml
+++ b/.github/workflows/statistic-tests.yml
@@ -24,7 +24,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install all scripts
         run: make && sudo make install
 
@@ -38,12 +38,12 @@ jobs:
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -1,7 +1,6 @@
 name: Tool Tests
 
 env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   MICROSOFT_EMAIL: gindibay@microsoft.com
   USER_NAME: Gurkan Indibay
   MAIN_BRANCH: all-citus
@@ -27,6 +26,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -30,7 +30,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -30,7 +30,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
+          app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_KEY }}
           owner: citusdata
 

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -5,6 +5,7 @@ import subprocess
 from enum import Enum
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 import docker
@@ -398,7 +399,7 @@ def get_docker_image_name(platform: str):
 @validate_parameters
 # disabled since this is related to parameter_validations library methods
 # pylint: disable=no-value-for-parameter
-# pylint: disable= too-many-locals
+# pylint: disable= too-many-locals, too-many-arguments
 def build_packages(
     github_token: non_empty(non_blank(str)),
     platform: non_empty(non_blank(str)),
@@ -406,6 +407,7 @@ def build_packages(
     signing_credentials: SigningCredentials,
     input_output_parameters: InputOutputParameters,
     is_test: bool = False,
+    postgres_version: Optional[str] = None,
 ) -> None:
     os_name, os_version = decode_os_and_release(platform)
     release_versions, nightly_versions = get_postgres_versions(
@@ -437,6 +439,13 @@ def build_packages(
         postgres_docker_extension_iterator = ["all"]
     else:
         postgres_docker_extension_iterator = postgress_versions_to_process
+        if postgres_version:
+            if postgres_version not in postgress_versions_to_process:
+                raise ValueError(
+                    f"Requested postgres_version '{postgres_version}' is not in the "
+                    f"{build_type.name} versions for '{platform}': {postgress_versions_to_process}"
+                )
+            postgres_docker_extension_iterator = [postgres_version]
 
     docker_image_name = get_docker_image_name(platform)
     output_sub_folder = get_release_package_folder_name(os_name, os_version)

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -73,6 +73,7 @@ REPO_CLIENT_SECRET = os.getenv("REPO_CLIENT_SECRET")
 PLATFORM = get_build_platform(
     os.getenv("PLATFORM"), os.getenv("PACKAGING_IMAGE_PLATFORM")
 )
+POSTGRES_VERSION = os.getenv("POSTGRES_VERSION")
 PACKAGING_BRANCH_NAME = os.getenv("PACKAGING_BRANCH_NAME", "all-citus-unit-tests")
 
 
@@ -130,6 +131,7 @@ def test_build_packages():
         signing_credentials,
         input_output_parameters,
         is_test=True,
+        postgres_version=POSTGRES_VERSION,
     )
     verify_rpm_signature_in_dir(BASE_OUTPUT_FOLDER)
     os_name, os_version = decode_os_and_release(PLATFORM)

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -107,8 +107,8 @@ def teardown_module():
 
 
 def test_build_packages():
-    # dev5 Fix A: the packaging per-pg CI matrix enumerates pg{14..18} per rpm distro to drive
-    # update_image into building every {os}-pg{N} base image, but tools' rpm release set is only
+    # The packaging per-pg CI matrix enumerates pg{14..18} per rpm distro to drive
+    # update_image into building every {os}-pg{N} base image, but the rpm release set is only
     # a subset (e.g. [15,16,17]). When POSTGRES_VERSION targets a version outside that set, there
     # is nothing for this test to build/sign, so skip gracefully (skip == success) rather than
     # letting build_packages raise. The image for that pg was still built by update_image, so
@@ -169,11 +169,11 @@ def test_build_packages():
 
     postgres_version_file_path = f"{PACKAGING_EXEC_FOLDER}/{POSTGRES_VERSION_FILE}"
     if PLATFORM != "pgxn":
-        # dev5 Fix B: when POSTGRES_VERSION restricts the build to a single in-set version,
+        # When POSTGRES_VERSION restricts the build to a single in-set version,
         # only that version's packages are produced, so the expected count is the per-version
         # package count (single_postgres_package_counts), not the full len(release_versions) *
         # per-version count. When POSTGRES_VERSION is empty/None (nightlies/CLI/deb/pgxn), keep
-        # the original all-versions expectation.
+        # the all-versions expectation.
         if POSTGRES_VERSION:
             expected_package_count = single_postgres_package_counts[PLATFORM]
         else:

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -2,6 +2,7 @@ import glob
 import os
 
 import pathlib2
+import pytest
 from dotenv import dotenv_values
 
 from .test_utils import generate_new_gpg_key
@@ -106,6 +107,21 @@ def teardown_module():
 
 
 def test_build_packages():
+    # dev5 Fix A: the packaging per-pg CI matrix enumerates pg{14..18} per rpm distro to drive
+    # update_image into building every {os}-pg{N} base image, but tools' rpm release set is only
+    # a subset (e.g. [15,16,17]). When POSTGRES_VERSION targets a version outside that set, there
+    # is nothing for this test to build/sign, so skip gracefully (skip == success) rather than
+    # letting build_packages raise. The image for that pg was still built by update_image, so
+    # push_images downstream still reseeds it.
+    if POSTGRES_VERSION and PLATFORM != "pgxn":
+        release_versions, _ = get_postgres_versions(
+            platform=PLATFORM, input_files_dir=PACKAGING_EXEC_FOLDER
+        )
+        if POSTGRES_VERSION not in release_versions:
+            pytest.skip(
+                f"pg{POSTGRES_VERSION} not in release set {release_versions} for {PLATFORM}"
+            )
+
     delete_all_gpg_keys_by_name(TEST_GPG_KEY_NAME)
     delete_rpm_key_by_name(TEST_GPG_KEY_NAME)
     generate_new_gpg_key(
@@ -153,9 +169,18 @@ def test_build_packages():
 
     postgres_version_file_path = f"{PACKAGING_EXEC_FOLDER}/{POSTGRES_VERSION_FILE}"
     if PLATFORM != "pgxn":
-        assert len(os.listdir(release_output_folder)) == get_required_package_count(
-            input_files_dir=PACKAGING_EXEC_FOLDER, platform=PLATFORM
-        )
+        # dev5 Fix B: when POSTGRES_VERSION restricts the build to a single in-set version,
+        # only that version's packages are produced, so the expected count is the per-version
+        # package count (single_postgres_package_counts), not the full len(release_versions) *
+        # per-version count. When POSTGRES_VERSION is empty/None (nightlies/CLI/deb/pgxn), keep
+        # the original all-versions expectation.
+        if POSTGRES_VERSION:
+            expected_package_count = single_postgres_package_counts[PLATFORM]
+        else:
+            expected_package_count = get_required_package_count(
+                input_files_dir=PACKAGING_EXEC_FOLDER, platform=PLATFORM
+            )
+        assert len(os.listdir(release_output_folder)) == expected_package_count
         assert os.path.exists(postgres_version_file_path)
         config = dotenv_values(postgres_version_file_path)
         assert config["release_versions"] == "15,16,17"

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -10,12 +10,14 @@ from ..citus_package import (
     POSTGRES_VERSION_FILE,
     BuildType,
     InputOutputParameters,
+    PostgresVersionDockerImageType,
     SigningCredentials,
     build_packages,
     decode_os_and_release,
     get_build_platform,
     get_release_package_folder_name,
     get_postgres_versions,
+    platform_postgres_version_source,
 )
 from ..common_tool_methods import (
     define_rpm_public_key_to_machine,
@@ -107,13 +109,24 @@ def teardown_module():
 
 
 def test_build_packages():
+    # postgres_version only narrows the build for "multiple"-image platforms (rpm distros),
+    # where build_packages iterates one docker image per pg version. For "single"-image platforms
+    # (debian/ubuntu/pgxn) the iterator is always ["all"], so postgres_version is a no-op and every
+    # release version is built regardless of what is passed. Gate the filter-aware branches below on
+    # that distinction so the test's skip/count logic always matches what build_packages actually
+    # does, no matter what the external packaging matrix passes for a single-image platform.
+    os_name, _ = decode_os_and_release(PLATFORM)
+    version_filter_active = bool(POSTGRES_VERSION) and (
+        platform_postgres_version_source[os_name]
+        == PostgresVersionDockerImageType.multiple
+    )
     # The packaging per-pg CI matrix enumerates pg{14..18} per rpm distro to drive
     # update_image into building every {os}-pg{N} base image, but the rpm release set is only
     # a subset (e.g. [15,16,17]). When POSTGRES_VERSION targets a version outside that set, there
     # is nothing for this test to build/sign, so skip gracefully (skip == success) rather than
     # letting build_packages raise. The image for that pg was still built by update_image, so
     # push_images downstream still reseeds it.
-    if POSTGRES_VERSION and PLATFORM != "pgxn":
+    if version_filter_active:
         release_versions, _ = get_postgres_versions(
             platform=PLATFORM, input_files_dir=PACKAGING_EXEC_FOLDER
         )
@@ -150,7 +163,7 @@ def test_build_packages():
         postgres_version=POSTGRES_VERSION,
     )
     verify_rpm_signature_in_dir(BASE_OUTPUT_FOLDER)
-    os_name, os_version = decode_os_and_release(PLATFORM)
+    _, os_version = decode_os_and_release(PLATFORM)
     sub_folder = get_release_package_folder_name(os_name, os_version)
     release_output_folder = f"{BASE_OUTPUT_FOLDER}/{sub_folder}"
     # Regression guard for the sign_packages path-doubling bug: the build output folder and the
@@ -169,12 +182,13 @@ def test_build_packages():
 
     postgres_version_file_path = f"{PACKAGING_EXEC_FOLDER}/{POSTGRES_VERSION_FILE}"
     if PLATFORM != "pgxn":
-        # When POSTGRES_VERSION restricts the build to a single in-set version,
-        # only that version's packages are produced, so the expected count is the per-version
-        # package count (single_postgres_package_counts), not the full len(release_versions) *
-        # per-version count. When POSTGRES_VERSION is empty/None (nightlies/CLI/deb/pgxn), keep
-        # the all-versions expectation.
-        if POSTGRES_VERSION:
+        # When POSTGRES_VERSION restricts the build to a single in-set version (multiple-image
+        # platforms only), only that version's packages are produced, so the expected count is the
+        # per-version package count (single_postgres_package_counts), not the full
+        # len(release_versions) * per-version count. When the filter is inactive — POSTGRES_VERSION
+        # empty/None, or a single-image platform where it is a no-op — keep the all-versions
+        # expectation.
+        if version_filter_active:
             expected_package_count = single_postgres_package_counts[PLATFORM]
         else:
             expected_package_count = get_required_package_count(

--- a/packaging_automation/tests/test_common_tool_methods.py
+++ b/packaging_automation/tests/test_common_tool_methods.py
@@ -4,10 +4,10 @@ from datetime import datetime
 from shutil import copyfile
 
 from datetime import timezone
+from unittest.mock import MagicMock
 
 
 import pathlib2
-from github import Github
 
 from .test_utils import generate_new_gpg_key
 from ..common_tool_methods import (
@@ -46,7 +46,6 @@ from ..common_tool_methods import (
     str_array_to_str,
 )
 
-GITHUB_TOKEN = os.getenv("GH_TOKEN")
 BASE_PATH = pathlib2.Path(__file__).parents[1]
 TEST_BASE_PATH = pathlib2.Path(__file__).parent.absolute()
 TEST_GPG_KEY_NAME = "Citus Data <packaging@citusdata.com>"
@@ -262,28 +261,66 @@ def test_prepend_line_in_file():
         os.remove(test_file)
 
 
+def _utc_date(date_str: str) -> datetime:
+    return datetime.strptime(date_str, "%Y.%m.%d").replace(tzinfo=timezone.utc)
+
+
+def _mock_pull_request(number, merged_at, label_names=()):
+    pull_request = MagicMock()
+    pull_request.number = number
+    pull_request.merged_at = merged_at
+    labels = []
+    for label_name in label_names:
+        label = MagicMock()
+        label.name = label_name
+        labels.append(label)
+    pull_request.labels = labels
+    return pull_request
+
+
 def test_getprs():
-    # created at is not seen on Github. Should be checked on API result
-    g = Github(GITHUB_TOKEN)
-    repository = g.get_repo("citusdata/citus")
+    # get_prs_for_patch_release paginates every closed PR of the base repo through
+    # the live GitHub API. The hardcoded 2021 window forces walking citus's entire
+    # PR history, which intermittently trips a PyGithub redirect-loop error on deep
+    # pages. Mock the repository so the date-window filtering and merge-date sort are
+    # exercised deterministically and offline.
+    repository = MagicMock()
+    repository.get_pulls.return_value = [
+        _mock_pull_request(4748, _utc_date("2021.02.26")),
+        _mock_pull_request(4750, _utc_date("2021.02.27")),
+        _mock_pull_request(4753, _utc_date("2021.02.28")),
+        _mock_pull_request(4760, _utc_date("2021.03.01")),
+        _mock_pull_request(4762, _utc_date("2021.03.01")),
+        _mock_pull_request(4769, _utc_date("2021.03.02")),
+        _mock_pull_request(4700, _utc_date("2021.02.20")),  # before window
+        _mock_pull_request(4799, _utc_date("2021.03.10")),  # after window
+        _mock_pull_request(4800, None),  # not merged
+    ]
     prs = get_prs_for_patch_release(
         repository,
-        datetime.strptime("2021.02.26", "%Y.%m.%d").replace(tzinfo=timezone.utc),
+        _utc_date("2021.02.26"),
         "master",
-        datetime.strptime("2021.03.02", "%Y.%m.%d").replace(tzinfo=timezone.utc),
+        _utc_date("2021.03.02"),
     )
     assert len(prs) == 6
     assert prs[0].number == 4748
 
 
 def test_getprs_with_backlog_label():
-    g = Github(GITHUB_TOKEN)
-    repository = g.get_repo("citusdata/citus")
+    repository = MagicMock()
+    repository.get_pulls.return_value = [
+        _mock_pull_request(4746, _utc_date("2021.02.25"), label_names=("backport",)),
+        _mock_pull_request(4740, _utc_date("2021.02.21"), label_names=("bug",)),
+        _mock_pull_request(4744, _utc_date("2021.02.24")),
+        _mock_pull_request(4730, _utc_date("2021.02.10"), label_names=("backport",)),
+        _mock_pull_request(4790, _utc_date("2021.03.05"), label_names=("backport",)),
+        _mock_pull_request(4795, None, label_names=("backport",)),
+    ]
     prs = get_prs_for_patch_release(
         repository,
-        datetime.strptime("2021.02.20", "%Y.%m.%d").replace(tzinfo=timezone.utc),
+        _utc_date("2021.02.20"),
         "master",
-        datetime.strptime("2021.02.27", "%Y.%m.%d").replace(tzinfo=timezone.utc),
+        _utc_date("2021.02.27"),
     )
     prs_backlog = filter_prs_by_label(prs, "backport")
     assert len(prs_backlog) == 1


### PR DESCRIPTION
## Summary

Stacked validation branch for the tools side of the GH_TOKEN → GitHub App token migration, plus the per-PostgreSQL-version `build_packages` filter used by the packaging per-pg CI matrix. **Base is #409 (`ihalatci/sign-rpm-packages`)** so this PR shows only the incremental work on top of the RPM-signing fixes; it will retarget to `develop` automatically once #409 merges.

**PR for review only — do not merge yet (gated).**

## What this stack contains (on top of #409)

1. **Phase 1 — GitHub App token in tools test workflows** (commits `836fd65`, `b148bde`): mint a GitHub App installation token and resolve the App ID via repo vars with a secrets fallback, across the tools test/CI workflows. App ID/private-key inputs are drop-in; `outputs.token` replaces the PAT.
2. **dev3 — Node24 action hygiene** (commits `a985c72`, `a40f783`): bump `actions/checkout@v5`, `actions/setup-python@v6`, `github/codeql-action@v3`, `create-github-app-token@v3`, `docker/login-action@v4` so no Node16/Node20-deprecated actions remain. Token-mint step is green on every leg.
3. **dev4 — optional `postgres_version` filter for `build_packages`** (commit `7ff0365`): `build_packages()` gains a trailing `postgres_version: Optional[str] = None`. For multi-image rpm platforms (el/ol/almalinux) the test can now restrict the build to a single locally-built `{os}-pg{N}` image instead of docker-pulling every sibling version from the registry. The single-image (deb/ubuntu/pgxn → `["all"]`) path is unchanged; default `None` preserves the all-versions behavior for nightlies and the CLI.
4. **dev5 — test-harness fixes for the filter** (commit `ba5fcef`): in `test_build_packages`, (A) gracefully `pytest.skip` when `POSTGRES_VERSION` is outside the platform's release set (the image is still built by `update_image`, so downstream `push_images` reseeds it), and (B) assert the filtered per-version package count when a single version is selected, full count otherwise.
5. **Comment reword** (commit `03d88c0`): clarify the two inline comments in `test_build_packages` to describe the change itself (non-behavioral).

## Validation

- `prospector`: 0 messages; `black --check`: clean (both `citus_package.py` and `tests/test_citus_package.py`).
- `build_packages` callers unchanged at 2: the `__main__` CLI (passes nothing → `None` → all versions, nightlies unaffected) and the test.
- The #409 RPM-signing regression guard in `test_build_packages` (`verify_rpm_signature_in_dir` + `assert is_rpm_file_signed`) is untouched.
- CI on this branch: token-mint green on every leg; full suite green after the packaging-test images were reseeded with the bot-identity fix.

## Backward compatibility

deb/ubuntu/pgxn legs run with empty `POSTGRES_VERSION` → `None` → no skip, full-count assertion, `["all"]` iterator unchanged. The CLI and nightlies pass nothing and are unaffected.
