### PR TITLE
diag: surface stdout+stderr on build_package failure

### DIFF
--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -367,7 +367,11 @@ def build_package(
     if output.stdout:
         print("Output:" + output.stdout)
     if output.returncode != 0:
-        raise ValueError(output.stderr)
+        raise ValueError(
+            f"Build failed (rc={output.returncode}).\n"
+            f"STDOUT:\n{output.stdout}\n"
+            f"STDERR:\n{output.stderr}"
+        )
 
     if input_output_parameters.output_validation:
         validate_output(

--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -364,14 +364,14 @@ def build_package(
     print(f"Executing docker command: {docker_command}")
     output = run_with_output(docker_command, text=True)
 
-    if output.stdout:
-        print("Output:" + output.stdout)
     if output.returncode != 0:
         raise ValueError(
             f"Build failed (rc={output.returncode}).\n"
             f"STDOUT:\n{output.stdout}\n"
             f"STDERR:\n{output.stderr}"
         )
+    if output.stdout:
+        print("Output:" + output.stdout)
 
     if input_output_parameters.output_validation:
         validate_output(


### PR DESCRIPTION
Packaging build failures were masked by stderr-only docker pull preamble output. This now prints both stdout and stderr, including the return code, so the real container error is visible. No behavior change on success.