### PR TITLE
Use GitHub App token in nightly package build

### DIFF
--- a/.github/workflows/build-citus-community-nightlies.yml
+++ b/.github/workflows/build-citus-community-nightlies.yml
@@ -4,7 +4,6 @@ env:
   MAIN_BRANCH: "all-citus"
   PACKAGING_PASSPHRASE: ${{ secrets.PACKAGING_PASSPHRASE }}
   PACKAGING_SECRET_KEY: ${{ secrets.PACKAGING_SECRET_KEY }}
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   DOCKERHUB_USER_NAME: ${{ secrets.DOCKERHUB_USER_NAME }}
   DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 on:
@@ -37,6 +36,19 @@ jobs:
         with:
           fetch-depth: 1
           path: tools
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export GitHub App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       # This step is to fetch the images unanonymously to have higher bandwidth
       - name: Login to Docker Hub


### PR DESCRIPTION
## Problem

The scheduled **Build and publish citus community nightly packages** workflow (`build-citus-community-nightlies.yml`) started failing on all 7 platform matrix jobs at the "Build packages" step (e.g. [run 28634135942](https://github.com/citusdata/tools/actions/runs/28634135942)) with `could not determine commit for git ref main`.

**Root cause:** this nightly is the lone unmigrated straggler still consuming the shared org PAT `secrets.GH_TOKEN`. When citusdata/packaging migrated to a GitHub App token (#1189), the shared org PAT was subsequently retired externally (after 2026-07-02). Inside the `citus/packaging` container, `fetch_and_build_rpm`/`_deb` resolve the citus commit SHA via an authenticated GitHub API call (`~/.curlrc` injects `Authorization: token ${GITHUB_TOKEN}`); `curl -sf` fail-closes on the resulting 401, hiding the error → fast failure across all 7 jobs. Timeline: succeeded 07-02 02:21Z (PAT alive) → fails from 07-03 02:19Z (PAT dead).

## Fix

Mirror the packaging #1189 nightly pattern (and the proven-green in-repo precedent `citus-package-all-platforms-test.yml`):

1. Delete the dead `GH_TOKEN: ${{ secrets.GH_TOKEN }}` shadow from the top-level `env:` block.
2. Mint a GitHub App token after Checkout, before "Login to Docker Hub", and export **both** `GH_TOKEN` and `GITHUB_TOKEN` to `$GITHUB_ENV`.

Exporting `GITHUB_TOKEN` (not just `GH_TOKEN`) is essential: the failing call is the in-container `~/.curlrc` path that consumes `GITHUB_TOKEN`. The existing `--gh_token "${GH_TOKEN}"` invocation is left untouched — it now resolves to the freshly minted App token.

Net **+13 / −1**, single file. Creds confirmed available to `citusdata/tools` (5 sibling workflows already mint `create-github-app-token@v3` with `vars.GH_APP_ID` / `secrets.GH_APP_KEY` / `owner: citusdata` and run green on `develop`).

## Validation

Pushing this branch auto-fires the nightly (`push: "**"`); publish gates on `MAIN_BRANCH="all-citus"` ≠ this branch, so publish stays OFF — a build-only validation run.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>