### PR TITLE
Consolidate open packaging dependency updates

### DIFF
--- a/packaging_automation/pypi_stats_collector.py
+++ b/packaging_automation/pypi_stats_collector.py
@@ -5,7 +5,6 @@ import json
 from .dbconfig import Base, DbParams, db_session
 import os
 
-
 # Define the database connection
 db_name = os.getenv(
     "DB_NAME",

--- a/packaging_automation/requirements.txt
+++ b/packaging_automation/requirements.txt
@@ -25,7 +25,7 @@ certifi==2024.2.2
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==2.0.0
     # via
     #   cryptography
     #   pynacl
@@ -35,7 +35,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via black
-cryptography==42.0.7
+cryptography==46.0.6
     # via pyjwt
 dataproperty==1.0.1
     # via
@@ -65,7 +65,7 @@ flake8-polyfill==1.0.2
     # via pep8-naming
 gitdb==4.0.11
     # via gitpython
-gitpython==3.1.43
+gitpython==3.1.50
     # via
     #   -r tools/packaging_automation/requirements.in
     #   prospector
@@ -77,7 +77,7 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via pypistats
-idna==3.7
+idna==3.15
     # via
     #   anyio
     #   httpx
@@ -86,7 +86,7 @@ iniconfig==2.0.0
     # via pytest
 isort==5.13.2
     # via pylint
-jinja2==3.1.4
+jinja2==3.1.6
     # via -r tools/packaging_automation/requirements.in
 lazy-object-proxy==1.10.0
     # via astroid
@@ -144,7 +144,7 @@ pluggy==1.5.0
     # via pytest
 prettytable==3.10.0
     # via pypistats
-prospector[with-everything,with_everything]==1.10.3
+prospector[with-everything]==1.10.3
     # via -r tools/packaging_automation/requirements.in
 psycopg2-binary==2.9.9
     # via -r tools/packaging_automation/requirements.in
@@ -164,9 +164,10 @@ pyflakes==2.5.0
     #   prospector
 pygithub==2.3.0
     # via -r tools/packaging_automation/requirements.in
-pygments==2.18.0
+pygments==2.20.0
     # via
     #   pyroma
+    #   pytest
     #   rich
 pyjwt[crypto]==2.8.0
     # via pygithub
@@ -201,13 +202,13 @@ pyroma==4.2
     # via prospector
 pytablewriter[html]==1.2.0
     # via pypistats
-pytest==8.2.1
+pytest==9.0.3
     # via -r tools/packaging_automation/requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   pypistats
     #   typepy
-python-dotenv==1.0.1
+python-dotenv==1.2.2
     # via -r tools/packaging_automation/requirements.in
 python-gnupg==0.5.2
     # via -r tools/packaging_automation/requirements.in
@@ -222,7 +223,7 @@ pyyaml==6.0.1
     #   -r tools/packaging_automation/requirements.in
     #   bandit
     #   prospector
-requests==2.32.2
+requests==2.33.0
     # via
     #   -r tools/packaging_automation/requirements.in
     #   docker
@@ -281,15 +282,16 @@ typepy[datetime]==1.3.2
     #   dataproperty
     #   pytablewriter
     #   tabledata
-typing-extensions==4.12.0
+typing-extensions==4.15.0
     # via
     #   anyio
     #   astroid
     #   black
+    #   cryptography
     #   mypy
     #   pygithub
     #   sqlalchemy
-urllib3==2.2.1
+urllib3==2.7.0
     # via
     #   -r tools/packaging_automation/requirements.in
     #   docker

--- a/packaging_automation/requirements.txt
+++ b/packaging_automation/requirements.txt
@@ -35,7 +35,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via black
-cryptography==48.0.1
+cryptography==50.0.0
     # via pyjwt
 dataproperty==1.0.1
     # via
@@ -65,7 +65,7 @@ flake8-polyfill==1.0.2
     # via pep8-naming
 gitdb==4.0.11
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.57
     # via
     #   -r tools/packaging_automation/requirements.in
     #   prospector

--- a/packaging_automation/requirements.txt
+++ b/packaging_automation/requirements.txt
@@ -16,11 +16,11 @@ attrs==23.2.0
     # via -r tools/packaging_automation/requirements.in
 bandit==1.7.8
     # via prospector
-black==24.4.2
+black==26.3.1
     # via -r tools/packaging_automation/requirements.in
 build==1.2.1
     # via pyroma
-certifi==2024.2.2
+certifi==2024.7.4
     # via
     #   httpcore
     #   httpx
@@ -35,7 +35,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via black
-cryptography==46.0.6
+cryptography==48.0.1
     # via pyjwt
 dataproperty==1.0.1
     # via
@@ -71,9 +71,9 @@ gitpython==3.1.50
     #   prospector
 greenlet==3.0.3
     # via sqlalchemy
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.9
     # via httpx
 httpx==0.27.0
     # via pypistats
@@ -123,11 +123,12 @@ packaging==24.0
     #   pytest
     #   requirements-detector
     #   typepy
+    #   wheel
 parameters-validation==1.2.0
     # via -r tools/packaging_automation/requirements.in
 pathlib2==2.3.7.post1
     # via -r tools/packaging_automation/requirements.in
-pathspec==0.12.1
+pathspec==1.1.1
     # via black
 pathvalidate==3.2.0
     # via pytablewriter
@@ -169,7 +170,7 @@ pygments==2.20.0
     #   pyroma
     #   pytest
     #   rich
-pyjwt[crypto]==2.8.0
+pyjwt[crypto]==2.13.0
     # via pygithub
 pylint==2.17.7
     # via
@@ -190,7 +191,7 @@ pylint-plugin-utils==0.7
     #   pylint-celery
     #   pylint-django
     #   pylint-flask
-pynacl==1.5.0
+pynacl==1.6.2
     # via pygithub
 pypistats==1.5.0
     # via -r tools/packaging_automation/requirements.in
@@ -216,6 +217,8 @@ python-slugify==8.0.4
     # via pypistats
 python-string-utils==1.0.0
     # via -r tools/packaging_automation/requirements.in
+pytokens==0.4.1
+    # via black
 pytz==2024.1
     # via typepy
 pyyaml==6.0.1
@@ -290,6 +293,7 @@ typing-extensions==4.15.0
     #   cryptography
     #   mypy
     #   pygithub
+    #   pyjwt
     #   sqlalchemy
 urllib3==2.7.0
     # via
@@ -301,7 +305,7 @@ vulture==2.11
     # via prospector
 wcwidth==0.2.13
     # via prettytable
-wheel==0.43.0
+wheel==0.46.2
     # via -r tools/packaging_automation/requirements.in
 wrapt==1.16.0
     # via

--- a/packaging_automation/requirements.txt
+++ b/packaging_automation/requirements.txt
@@ -16,7 +16,7 @@ attrs==23.2.0
     # via -r tools/packaging_automation/requirements.in
 bandit==1.7.8
     # via prospector
-black==26.3.1
+black==26.5.1
     # via -r tools/packaging_automation/requirements.in
 build==1.2.1
     # via pyroma
@@ -65,7 +65,7 @@ flake8-polyfill==1.0.2
     # via pep8-naming
 gitdb==4.0.11
     # via gitpython
-gitpython==3.1.57
+gitpython==3.1.58
     # via
     #   -r tools/packaging_automation/requirements.in
     #   prospector
@@ -147,7 +147,7 @@ prettytable==3.10.0
     # via pypistats
 prospector[with-everything]==1.10.3
     # via -r tools/packaging_automation/requirements.in
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.12
     # via -r tools/packaging_automation/requirements.in
 pycodestyle==2.9.1
     # via
@@ -155,7 +155,7 @@ pycodestyle==2.9.1
     #   prospector
 pycparser==2.22
     # via cffi
-pycurl==7.45.3
+pycurl==7.47.0
     # via -r tools/packaging_automation/requirements.in
 pydocstyle==6.3.0
     # via prospector
@@ -203,7 +203,7 @@ pyroma==4.2
     # via prospector
 pytablewriter[html]==1.2.0
     # via pypistats
-pytest==9.0.3
+pytest==9.1.1
     # via -r tools/packaging_automation/requirements.in
 python-dateutil==2.9.0.post0
     # via


### PR DESCRIPTION
## Summary
- update Black from 26.3.1 to 26.5.1
- update cryptography from 48.0.1 to 50.0.0
- update GitPython from 3.1.50 to 3.1.58
- update psycopg2-binary from 2.9.9 to 2.9.12
- update pycurl from 7.45.3 to 7.47.0
- update pytest from 9.0.3 to 9.1.1
- cover every currently open Dependabot version-update PR with one consistent Python 3.10 lockfile

## Local validation
- regenerated lock exactly matches `pip-compile` under Python 3.10
- installed package set passes dependency compatibility checks
- Black formatting check passes
- Prospector reports zero findings
- 21 targeted packaging tests pass
- GitPython branch and commit access passes in a native WSL repository

CI exercises the repository's remaining Git- and Docker-backed workflows.