### PR TITLE
Fix nightly PostgreSQL exclusion filtering

### DIFF
--- a/packaging_automation/citus_package.py
+++ b/packaging_automation/citus_package.py
@@ -329,7 +329,7 @@ def get_postgres_versions(
     if exclude_dict_nightly and platform_key_nightly in exclude_dict_nightly:
         nightly_versions = [
             v
-            for v in release_versions
+            for v in nightly_versions
             if v not in exclude_dict_nightly[platform_key_nightly]
         ]
 

--- a/packaging_automation/tests/test_citus_package.py
+++ b/packaging_automation/tests/test_citus_package.py
@@ -223,7 +223,7 @@ def test_get_postgres_versions_ol_7():
     )
     # pg 15 is excluded for all releases with pg_exclude file
     assert len(release_versions) == 2 and release_versions == ["13", "14"]
-    assert len(nightly_versions) == 2 and nightly_versions == ["13", "14"]
+    assert len(nightly_versions) == 1 and nightly_versions == ["14"]
 
 
 def test_get_postgres_versions_el_7():


### PR DESCRIPTION
## Summary
- filter nightly PostgreSQL exclusions from `nightly_versions` instead of `release_versions`
- update the directly affected nightly exclusion test expectation

## Why
The bug is latent while `exclude.nightly` is empty: adding any nightly exclusion currently replaces the nightly matrix with filtered `release_versions`. Filtering `nightly_versions` preserves the intended nightly matrix while removing only the excluded PostgreSQL versions.

This is required by the companion all-citus matrix change that excludes PostgreSQL 19: https://github.com/citusdata/packaging/pull/1215. Both changes are required, but they can land in either order.